### PR TITLE
feat(game): 添加游戏 src 目录结构与占位文件 (Task2)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,9 @@ export default tseslint.config(
     languageOptions: {
       globals: { ...globals.browser },
     },
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    },
   },
   ...pluginVue.configs['flat/recommended'],
   {

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+// 棋盘组件：Canvas 或 DOM 渲染，接收行列数、落子回调等
+</script>
+
+<template>
+  <div class="game-board">
+    <!-- 棋盘容器，后续接入 Canvas 或格线 -->
+  </div>
+</template>
+
+<style scoped>
+.game-board {
+  /* 棋盘样式 */
+}
+</style>

--- a/src/components/game/GamePiece.vue
+++ b/src/components/game/GamePiece.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+// 棋子组件：单颗棋子展示（若用 DOM 渲染）；Canvas 方案可在 GameBoard 内统一绘制
+defineProps<{
+  color?: 'black' | 'white'
+}>()
+</script>
+
+<template>
+  <div class="game-piece" :data-color="color">
+    <!-- 棋子占位 -->
+  </div>
+</template>
+
+<style scoped>
+.game-piece {
+  /* 棋子样式 */
+}
+</style>

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -1,0 +1,2 @@
+export { default as GameBoard } from './GameBoard.vue'
+export { default as GamePiece } from './GamePiece.vue'

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useGameLogic } from './useGameLogic'
+export { useBoardRenderer } from './useBoardRenderer'

--- a/src/hooks/useBoardRenderer.ts
+++ b/src/hooks/useBoardRenderer.ts
@@ -1,0 +1,7 @@
+/**
+ * 棋盘渲染 Hook：Canvas 绘制、坐标换算、鼠标/触摸落点等
+ */
+export function useBoardRenderer() {
+  // TODO: canvas ref、绘制棋盘与棋子、像素/格子坐标转换
+  return {}
+}

--- a/src/hooks/useGameLogic.ts
+++ b/src/hooks/useGameLogic.ts
@@ -1,0 +1,7 @@
+/**
+ * 游戏逻辑 Hook：棋盘状态、落子、回合、胜负判定等
+ */
+export function useGameLogic() {
+  // TODO: 棋盘状态、当前玩家、落子、悔棋、重新开始等
+  return {}
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,6 @@
+/**
+ * 全局样式变量：主题色、棋盘尺寸、间距等，供组件与 style.css 引用
+ */
+:root {
+  /* 示例：--color-board-line: #333; --size-cell: 40px; */
+}

--- a/src/utils/checkWinner.ts
+++ b/src/utils/checkWinner.ts
@@ -1,0 +1,14 @@
+/**
+ * 五子棋胜负判断：给定棋盘与最后落子位置，判断是否五子连珠
+ */
+
+export type PieceColor = 'black' | 'white'
+
+export function checkWinner(
+  _board: PieceColor[][] | number[][],
+  _lastRow: number,
+  _lastCol: number
+): PieceColor | null {
+  // TODO: 沿横、竖、两斜共四向检测连续同色数量
+  return null
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { checkWinner, type PieceColor } from './checkWinner'

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,20 +1,29 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
+    "noEmit": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "moduleDetection": "force",
+    "jsx": "preserve",
+    "jsxImportSource": "vue",
+    "noImplicitThis": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "verbatimModuleSyntax": true,
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
     "incremental": true,
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "types": [
-      "vite/client"
-    ],
-    /* Linting */
-    "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src/**/*.ts",
-    "src/**/*.tsx",
-    "src/**/*.vue"
-  ]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
 }


### PR DESCRIPTION
## 变更类型

- [x] 功能 (feat)
- [ ] 修复 (fix)
- [ ] 文档 (docs)
- [ ] 重构/样式/其他 (refactor/style/chore)

## 描述

- components/game: GameBoard、GamePiece 占位组件及统一导出
- hooks: useGameLogic、useBoardRenderer 占位
- utils: checkWinner 胜负判断占位与 PieceColor 类型
- assets: .gitkeep 保留空目录
- styles: variables.css 全局变量占位
- eslint: argsIgnorePattern ^_ 支持占位参数
- tsconfig.app: 独立配置避免 libReplacement 兼容问题

## 关联

None

## 自测

- [X] 本地 `npm run dev` 正常
- [X] 本地 `npm run lint` 通过
- [X] 本地 `npm run build` 通过

## 备注

None

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds placeholder scaffolding and config tweaks; primary risk is TypeScript compiler option changes potentially affecting build/lint behavior across the app.
> 
> **Overview**
> Adds initial (mostly TODO/placeholder) game scaffolding: `GameBoard`/`GamePiece` Vue components with barrel exports, plus empty `useGameLogic` and `useBoardRenderer` hooks and a stubbed `checkWinner` utility/type.
> 
> Updates tooling/config: ESLint now ignores unused parameters prefixed with `_`, and `tsconfig.app.json` is rewritten with explicit modern bundler/ESNext-oriented compiler options (while keeping strictness and includes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eb015b5e7be96e7f2608f3d8f6e4d884b6c21f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->