### PR TITLE
feat: 15×15 棋盘 Canvas 绘制 (Issue 1)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,12 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import GameBoard from './components/game/GameBoard.vue'
+</script>
 
 <template>
   <div class="app">
-    <!-- 五子棋游戏主容器，后续接入棋盘等组件 -->
+    <div class="app__board-wrap">
+      <GameBoard />
+    </div>
   </div>
 </template>
 
@@ -12,5 +16,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  background: #f5f5f5;
+}
+.app__board-wrap {
+  width: min(90vmin, 420px);
+  height: min(90vmin, 420px);
+  background: #dcb35c;
+  border-radius: 4px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
 }
 </style>

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -1,15 +1,55 @@
 <script setup lang="ts">
-// 棋盘组件：Canvas 或 DOM 渲染，接收行列数、落子回调等
+import { ref, onMounted, onUnmounted } from 'vue'
+import { createBoardRenderer } from '../../renderer'
+
+const containerRef = ref<HTMLDivElement | null>(null)
+const canvasRef = ref<HTMLCanvasElement | null>(null)
+let resizeObserver: ResizeObserver | null = null
+
+function draw() {
+  const container = containerRef.value
+  const canvas = canvasRef.value
+  if (!container || !canvas) return
+  const w = container.clientWidth
+  const h = container.clientHeight
+  if (w <= 0 || h <= 0) return
+  const renderer = createBoardRenderer(canvas, {
+    containerWidth: w,
+    containerHeight: h,
+  })
+  renderer.drawBoard()
+}
+
+onMounted(() => {
+  draw()
+  const container = containerRef.value
+  if (!container) return
+  resizeObserver = new ResizeObserver(() => draw())
+  resizeObserver.observe(container)
+})
+
+onUnmounted(() => {
+  resizeObserver?.disconnect()
+})
 </script>
 
 <template>
-  <div class="game-board">
-    <!-- 棋盘容器，后续接入 Canvas 或格线 -->
+  <div ref="containerRef" class="game-board">
+    <canvas ref="canvasRef" class="game-board__canvas" />
   </div>
 </template>
 
 <style scoped>
 .game-board {
-  /* 棋盘样式 */
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.game-board__canvas {
+  display: block;
+  max-width: 100%;
+  max-height: 100%;
 }
 </style>

--- a/src/renderer/BoardRenderer.ts
+++ b/src/renderer/BoardRenderer.ts
@@ -1,0 +1,62 @@
+/**
+ * 棋盘渲染器：15×15 格线绘制，响应式尺寸
+ * scale = min(containerWidth, containerHeight) / 15
+ * 暴露 drawBoard()、clear()
+ */
+
+const BOARD_SIZE = 15
+const GRID_COLOR = '#333'
+const LINE_WIDTH = 1
+
+export interface BoardRendererOptions {
+  /** 容器宽度（像素） */
+  containerWidth: number
+  /** 容器高度（像素） */
+  containerHeight: number
+}
+
+/**
+ * 创建并返回棋盘渲染器方法，绑定当前 canvas 与尺寸
+ */
+export function createBoardRenderer(
+  canvas: HTMLCanvasElement,
+  options: BoardRendererOptions
+) {
+  const { containerWidth, containerHeight } = options
+  const scale =
+    Math.min(containerWidth, containerHeight) / BOARD_SIZE
+  const size = BOARD_SIZE * scale
+
+  return {
+    /** 绘制 15×15 格线（16×16 条线） */
+    drawBoard(): void {
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+
+      canvas.width = size
+      canvas.height = size
+
+      ctx.strokeStyle = GRID_COLOR
+      ctx.lineWidth = LINE_WIDTH
+
+      for (let i = 0; i <= BOARD_SIZE; i++) {
+        const p = i * scale
+        ctx.beginPath()
+        ctx.moveTo(p, 0)
+        ctx.lineTo(p, size)
+        ctx.stroke()
+        ctx.beginPath()
+        ctx.moveTo(0, p)
+        ctx.lineTo(size, p)
+        ctx.stroke()
+      }
+    },
+
+    /** 清空画布 */
+    clear(): void {
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+    },
+  }
+}

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,0 +1,2 @@
+export { createBoardRenderer } from './BoardRenderer.ts'
+export type { BoardRendererOptions } from './BoardRenderer.ts'


### PR DESCRIPTION
## 变更类型

- [x] 功能 (feat)
- [ ] 修复 (fix)
- [ ] 文档 (docs)
- [ ] 重构/样式/其他 (refactor/style/chore)

- 新增 src/renderer/BoardRenderer.ts：drawBoard()、clear()，scale=min(w,h)/15
- GameBoard.vue：canvas + ResizeObserver 响应式重绘
- App.vue：挂载棋盘容器，min(90vmin,420px) 方形区域

## 描述

使用 Canvas 2D 绘制 15*15 格线

## 关联

Closes #14 

## 自测

- [x] 本地 `npm run dev` 正常
- [x] 本地 `npm run lint` 通过
- [x] 本地 `npm run build` 通过