### PR TITLE
feat: 棋子绘制（黑/白）(Issue 3)

### DIFF
--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -4,8 +4,14 @@ import { createBoardRenderer, createCoordMapper } from '../../renderer'
 
 const containerRef = ref<HTMLDivElement | null>(null)
 const canvasRef = ref<HTMLCanvasElement | null>(null)
-/** 测试用：最后一次有效点击的 (row, col)，便于界面与控制台验证 */
+/** 测试用：最后一次有效点击的 (row, col) */
 const lastClick = ref<{ row: number; col: number } | null>(null)
+/** 本地棋盘状态，0 空 1 黑 2 白，用于手动测试棋子绘制（Issue 4 后将由 Pinia 替代） */
+const board = ref<number[][]>(
+  Array.from({ length: 15 }, () => Array(15).fill(0))
+)
+/** 当前落子方，1 黑 2 白 */
+const currentPlayer = ref<1 | 2>(1)
 let resizeObserver: ResizeObserver | null = null
 
 const BOARD_SIZE = 15
@@ -31,6 +37,7 @@ function draw() {
     containerHeight: h,
   })
   renderer.drawBoard()
+  renderer.drawPieces(board.value)
 }
 
 function handlePointerDown(e: PointerEvent) {
@@ -46,8 +53,15 @@ function handlePointerDown(e: PointerEvent) {
   const bitmapY = displayY * (canvas.height / rect.height)
   const logical = mapper.pixelToLogical(bitmapX, bitmapY)
   if (!logical) return
+  const { row, col } = logical
   lastClick.value = logical
-  console.log('[coord-mapper] click →', logical)
+  if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) return
+  const rowData = board.value[row]
+  if (!rowData || rowData[col] !== 0) return
+  rowData[col] = currentPlayer.value
+  currentPlayer.value = currentPlayer.value === 1 ? 2 : 1
+  draw()
+  console.log('[piece]', logical, rowData[col] === 1 ? '黑' : '白')
 }
 
 onMounted(() => {
@@ -70,8 +84,9 @@ onUnmounted(() => {
       class="game-board__canvas"
       @pointerdown="handlePointerDown"
     />
-    <div v-if="lastClick !== null" class="game-board__hint" aria-live="polite">
-      测试：上次点击 ({{ lastClick.row }}, {{ lastClick.col }})
+    <div class="game-board__hint" aria-live="polite">
+      <span>当前：{{ currentPlayer === 1 ? '黑' : '白' }}方</span>
+      <span v-if="lastClick !== null"> · 上次 ({{ lastClick.row }}, {{ lastClick.col }})</span>
     </div>
   </div>
 </template>

--- a/src/renderer/BoardRenderer.test.ts
+++ b/src/renderer/BoardRenderer.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { createBoardRenderer } from './BoardRenderer.ts'
+
+const hasCanvas =
+  typeof globalThis.document !== 'undefined' &&
+  typeof globalThis.document.createElement === 'function'
+
+describe('createBoardRenderer', () => {
+  it.skipIf(!hasCanvas)('returns drawBoard, drawPiece, drawPieces, clear', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    expect(typeof renderer.drawBoard).toBe('function')
+    expect(typeof renderer.drawPiece).toBe('function')
+    expect(typeof renderer.drawPieces).toBe('function')
+    expect(typeof renderer.clear).toBe('function')
+  })
+
+  it.skipIf(!hasCanvas)('drawBoard then drawPiece does not throw', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    renderer.drawBoard()
+    expect(() => renderer.drawPiece(0, 0, 1)).not.toThrow()
+    expect(() => renderer.drawPiece(7, 7, 2)).not.toThrow()
+  })
+
+  it.skipIf(!hasCanvas)('drawPieces with board array does not throw', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    renderer.drawBoard()
+    const board = Array.from({ length: 15 }, () => Array(15).fill(0)) as number[][]
+    board[0]![0] = 1
+    board[14]![14] = 2
+    board[7]![7] = 1
+    expect(() => renderer.drawPieces(board)).not.toThrow()
+  })
+
+  it.skipIf(!hasCanvas)('clear does not throw', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    renderer.drawBoard()
+    expect(() => renderer.clear()).not.toThrow()
+  })
+})

--- a/src/renderer/BoardRenderer.ts
+++ b/src/renderer/BoardRenderer.ts
@@ -1,12 +1,17 @@
 /**
- * 棋盘渲染器：15×15 格线绘制，响应式尺寸
+ * 棋盘渲染器：15×15 格线绘制，棋子绘制，响应式尺寸
  * scale = min(containerWidth, containerHeight) / 15
- * 暴露 drawBoard()、clear()
+ * 暴露 drawBoard()、drawPiece()、drawPieces()、clear()
  */
 
 const BOARD_SIZE = 15
 const GRID_COLOR = '#333'
 const LINE_WIDTH = 1
+/** 棋子颜色：1 黑 2 白，与 store board 约定一致 */
+export type PieceColor = 1 | 2
+const PIECE_RADIUS_RATIO = 0.45
+/** 白子描边：浅灰，在浅色棋盘上可见且不突兀 */
+const WHITE_STROKE = '#999'
 
 export interface BoardRendererOptions {
   /** 容器宽度（像素） */
@@ -54,6 +59,45 @@ export function createBoardRenderer(
         ctx.moveTo(gridMin, p)
         ctx.lineTo(gridMax, p)
         ctx.stroke()
+      }
+    },
+
+    /**
+     * 在交点 (row, col) 绘制一枚棋子，color 1 黑 2 白
+     * 渲染层不持有状态，由调用方传入
+     */
+    drawPiece(row: number, col: number, color: PieceColor): void {
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      const centerX = offset + col * scale
+      const centerY = offset + row * scale
+      const radius = scale * PIECE_RADIUS_RATIO
+      ctx.beginPath()
+      ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+      if (color === 1) {
+        ctx.fillStyle = '#000'
+        ctx.fill()
+      } else {
+        ctx.fillStyle = '#fff'
+        ctx.fill()
+        ctx.strokeStyle = WHITE_STROKE
+        ctx.lineWidth = LINE_WIDTH
+        ctx.stroke()
+      }
+    },
+
+    /**
+     * 根据 board 二维数组重绘所有棋子，0 空 1 黑 2 白
+     * 不持有状态，仅根据传入的 board 绘制
+     */
+    drawPieces(board: number[][]): void {
+      for (let row = 0; row < BOARD_SIZE; row++) {
+        for (let col = 0; col < BOARD_SIZE; col++) {
+          const v = board[row]?.[col]
+          if (v === 1 || v === 2) {
+            this.drawPiece(row, col, v as PieceColor)
+          }
+        }
       }
     },
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,4 @@
 export { createBoardRenderer } from './BoardRenderer.ts'
-export type { BoardRendererOptions } from './BoardRenderer.ts'
+export type { BoardRendererOptions, PieceColor } from './BoardRenderer.ts'
 export { createCoordMapper, BOARD_SIZE } from './coordMapper.ts'
 export type { LogicalPoint, PixelPoint } from './coordMapper.ts'


### PR DESCRIPTION
## 变更类型

- [x] 功能 (feat)
- [ ] 修复 (fix)
- [ ] 文档 (docs)
- [ ] 重构/样式/其他 (refactor/style/chore)

## 描述

- BoardRenderer: drawPiece(row, col, color)、drawPieces(board)，交点画黑/白圆
- 渲染层不持状态，由调用方传入 board；白子描边 #999
- GameBoard: 本地 board/currentPlayer 用于手动测试，点击落子后重绘
- BoardRenderer.test.ts: drawBoard/drawPiece/drawPieces/clear 用例（无 document 时跳过)

## 关联

Closes #19 

## 自测

- [x] 本地 `npm run dev` 正常
- [x] 本地 `npm run lint` 通过
- [x] 本地 `npm run build` 通过