### PR TITLE
feat: 棋盘状态与落子逻辑（Pinia）(Issue 4)

### DIFF
--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
+import { storeToRefs } from 'pinia'
 import { createBoardRenderer, createCoordMapper } from '../../renderer'
+import { useGameStore } from '../../stores'
+
+const gameStore = useGameStore()
+const { board, currentPlayer } = storeToRefs(gameStore)
 
 const containerRef = ref<HTMLDivElement | null>(null)
 const canvasRef = ref<HTMLCanvasElement | null>(null)
-/** 测试用：最后一次有效点击的 (row, col) */
+/** 最后一次有效点击的 (row, col)；非法落子时的提示信息 */
 const lastClick = ref<{ row: number; col: number } | null>(null)
-/** 本地棋盘状态，0 空 1 黑 2 白，用于手动测试棋子绘制（Issue 4 后将由 Pinia 替代） */
-const board = ref<number[][]>(
-  Array.from({ length: 15 }, () => Array(15).fill(0))
-)
-/** 当前落子方，1 黑 2 白 */
-const currentPlayer = ref<1 | 2>(1)
+const lastMessage = ref<string | null>(null)
 let resizeObserver: ResizeObserver | null = null
 
-const BOARD_SIZE = 15
+const BOARD_SIZE = gameStore.boardSize
 
 function getScale(): number {
   const container = containerRef.value
@@ -54,14 +54,14 @@ function handlePointerDown(e: PointerEvent) {
   const logical = mapper.pixelToLogical(bitmapX, bitmapY)
   if (!logical) return
   const { row, col } = logical
-  lastClick.value = logical
-  if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) return
-  const rowData = board.value[row]
-  if (!rowData || rowData[col] !== 0) return
-  rowData[col] = currentPlayer.value
-  currentPlayer.value = currentPlayer.value === 1 ? 2 : 1
-  draw()
-  console.log('[piece]', logical, rowData[col] === 1 ? '黑' : '白')
+  lastMessage.value = null
+  const result = gameStore.placeStone(row, col)
+  if (result.success) {
+    lastClick.value = logical
+    draw()
+  } else {
+    lastMessage.value = result.message
+  }
 }
 
 onMounted(() => {
@@ -87,6 +87,7 @@ onUnmounted(() => {
     <div class="game-board__hint" aria-live="polite">
       <span>当前：{{ currentPlayer === 1 ? '黑' : '白' }}方</span>
       <span v-if="lastClick !== null"> · 上次 ({{ lastClick.row }}, {{ lastClick.col }})</span>
+      <span v-if="lastMessage" class="game-board__hint--error">{{ lastMessage }}</span>
     </div>
   </div>
 </template>
@@ -118,5 +119,9 @@ onUnmounted(() => {
   padding: 0.15rem 0.5rem;
   border-radius: 4px;
   pointer-events: none;
+}
+.game-board__hint--error {
+  color: #c00;
+  margin-left: 0.25rem;
 }
 </style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,8 @@
 import { createApp } from 'vue'
+import { createPinia } from 'pinia'
 import './style.css'
 import App from './App.vue'
 
-createApp(App).mount('#app')
+const app = createApp(App)
+app.use(createPinia())
+app.mount('#app')

--- a/src/stores/game.test.ts
+++ b/src/stores/game.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useGameStore } from './game'
+
+describe('useGameStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('initial state: empty board, black first, playing', () => {
+    const store = useGameStore()
+    expect(store.board.every((row) => row.every((c) => c === 0))).toBe(true)
+    expect(store.currentPlayer).toBe(1)
+    expect(store.history).toHaveLength(0)
+    expect(store.status).toBe('playing')
+    expect(store.canPlay).toBe(true)
+  })
+
+  it('placeStone: success updates board, history, and switches player', () => {
+    const store = useGameStore()
+    const r = store.placeStone(0, 0)
+    expect(r.success).toBe(true)
+    expect(store.board[0]![0]).toBe(1)
+    expect(store.history).toHaveLength(1)
+    expect(store.history[0]).toEqual({ row: 0, col: 0, player: 1 })
+    expect(store.currentPlayer).toBe(2)
+
+    const r2 = store.placeStone(1, 1)
+    expect(r2.success).toBe(true)
+    expect(store.board[1]![1]).toBe(2)
+    expect(store.history).toHaveLength(2)
+    expect(store.currentPlayer).toBe(1)
+  })
+
+  it('placeStone: reject duplicate move and do not push history', () => {
+    const store = useGameStore()
+    store.placeStone(0, 0)
+    const len = store.history.length
+    const result = store.placeStone(0, 0)
+    expect(result.success).toBe(false)
+    expect((result as { message: string }).message).toBe('该位置已有棋子')
+    expect(store.history).toHaveLength(len)
+  })
+
+  it('placeStone: reject out of bounds', () => {
+    const store = useGameStore()
+    expect(store.placeStone(-1, 0).success).toBe(false)
+    expect(store.placeStone(0, 15).success).toBe(false)
+    expect(store.placeStone(15, 0).success).toBe(false)
+    expect(store.history).toHaveLength(0)
+  })
+
+  it('resetGame: clears board, history, black first', () => {
+    const store = useGameStore()
+    store.placeStone(0, 0)
+    store.placeStone(1, 1)
+    store.resetGame()
+    expect(store.board.every((row) => row.every((c) => c === 0))).toBe(true)
+    expect(store.history).toHaveLength(0)
+    expect(store.currentPlayer).toBe(1)
+    expect(store.status).toBe('playing')
+  })
+})

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,0 +1,75 @@
+/**
+ * 对局状态与落子逻辑（Pinia）
+ * 状态：board、currentPlayer、history、status
+ * 落子前校验空位与当前玩家；非法落子不写 history，返回提示
+ */
+
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+const BOARD_SIZE = 15
+
+export type Player = 1 | 2
+export type GameStatus = 'playing' | 'black_win' | 'white_win' | 'draw'
+
+export interface HistoryEntry {
+  row: number
+  col: number
+  player: Player
+}
+
+function createEmptyBoard(): number[][] {
+  return Array.from({ length: BOARD_SIZE }, () => Array(BOARD_SIZE).fill(0))
+}
+
+export const useGameStore = defineStore('game', () => {
+  const board = ref<number[][]>(createEmptyBoard())
+  const currentPlayer = ref<Player>(1)
+  const history = ref<HistoryEntry[]>([])
+  const status = ref<GameStatus>('playing')
+
+  const canPlay = computed(() => status.value === 'playing')
+
+  /**
+   * 落子：校验空位与当前玩家，合法则写入 history 并更新 board、切换玩家
+   * @returns 成功返回 { success: true }，失败返回 { success: false, message }
+   */
+  function placeStone(row: number, col: number): { success: true } | { success: false; message: string } {
+    if (status.value !== 'playing') {
+      return { success: false, message: '对局已结束' }
+    }
+    if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) {
+      return { success: false, message: '落子超出棋盘' }
+    }
+    const rowData = board.value[row]
+    if (!rowData || rowData[col] !== 0) {
+      return { success: false, message: '该位置已有棋子' }
+    }
+    const player = currentPlayer.value
+    rowData[col] = player
+    history.value.push({ row, col, player })
+    currentPlayer.value = (player === 1 ? 2 : 1) as Player
+    return { success: true }
+  }
+
+  /**
+   * 重置对局：清空棋盘、历史，黑方先手，状态为 playing
+   */
+  function resetGame(): void {
+    board.value = createEmptyBoard()
+    currentPlayer.value = 1
+    history.value = []
+    status.value = 'playing'
+  }
+
+  return {
+    board,
+    currentPlayer,
+    history,
+    status,
+    canPlay,
+    placeStone,
+    resetGame,
+    boardSize: BOARD_SIZE,
+  }
+})

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,2 @@
+export { useGameStore } from './game'
+export type { Player, GameStatus, HistoryEntry } from './game'


### PR DESCRIPTION
## 变更类型

- [x] 功能 (feat)
- [ ] 修复 (fix)
- [ ] 文档 (docs)
- [ ] 重构/样式/其他 (refactor/style/chore)

## 描述

- useGameStore: board, currentPlayer, history, status
- placeStone: 校验空位与当前玩家，非法落子不写 history 并返回 message
- resetGame: 清空棋盘与历史
- GameBoard 接入 store，非法落子时展示提示
- 单元测试覆盖 store 行为

## 关联

Closes #22 

## 自测

- [x] 本地 `npm run dev` 正常
- [x] 本地 `npm run lint` 通过
- [x] 本地 `npm run build` 通过

## 备注

<!-- 其他需要 Reviewer 关注的点 -->
