### PR TITLE
feat: 对局结束与重新开始 (Issue 6)

### DIFF
--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -5,7 +5,7 @@ import { createBoardRenderer, createCoordMapper } from '../../renderer'
 import { useGameStore } from '../../stores'
 
 const gameStore = useGameStore()
-const { board, currentPlayer } = storeToRefs(gameStore)
+const { board, currentPlayer, status } = storeToRefs(gameStore)
 
 const containerRef = ref<HTMLDivElement | null>(null)
 const canvasRef = ref<HTMLCanvasElement | null>(null)
@@ -64,6 +64,13 @@ function handlePointerDown(e: PointerEvent) {
   }
 }
 
+function handleRestart() {
+  gameStore.resetGame()
+  lastClick.value = null
+  lastMessage.value = null
+  draw()
+}
+
 onMounted(() => {
   draw()
   const container = containerRef.value
@@ -85,9 +92,19 @@ onUnmounted(() => {
       @pointerdown="handlePointerDown"
     />
     <div class="game-board__hint" aria-live="polite">
-      <span>当前：{{ currentPlayer === 1 ? '黑' : '白' }}方</span>
-      <span v-if="lastClick !== null"> · 上次 ({{ lastClick.row }}, {{ lastClick.col }})</span>
+      <template v-if="status === 'playing'">
+        <span>当前：{{ currentPlayer === 1 ? '黑' : '白' }}方</span>
+        <span v-if="lastClick !== null"> · 上次 ({{ lastClick.row }}, {{ lastClick.col }})</span>
+      </template>
+      <span v-else-if="status === 'black_win'">黑方胜</span>
+      <span v-else-if="status === 'white_win'">白方胜</span>
       <span v-if="lastMessage" class="game-board__hint--error">{{ lastMessage }}</span>
+    </div>
+    <div v-if="status !== 'playing'" class="game-board__overlay" role="dialog" aria-label="对局结束">
+      <p class="game-board__result">
+        {{ status === 'black_win' ? '黑方胜' : status === 'white_win' ? '白方胜' : '和棋' }}
+      </p>
+      <button type="button" class="game-board__restart" @click="handleRestart">重新开始</button>
     </div>
   </div>
 </template>
@@ -123,5 +140,34 @@ onUnmounted(() => {
 .game-board__hint--error {
   color: #c00;
   margin-left: 0.25rem;
+}
+.game-board__overlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  border-radius: 8px;
+}
+.game-board__result {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #fff;
+}
+.game-board__restart {
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  color: #333;
+  background: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.game-board__restart:hover {
+  background: #f0f0f0;
 }
 </style>


### PR DESCRIPTION
## 变更类型

- [x] 功能 (feat)
- [ ] 修复 (fix)
- [ ] 文档 (docs)
- [ ] 重构/样式/其他 (refactor/style/chore)

## 描述

- 一方获胜后展示结果：底部 hint 与半透明遮罩弹层显示黑方胜/白方胜
- 提供「重新开始」按钮，调用 resetGame 并重绘棋盘
- 和棋文案预留（逻辑可选未实现）

## 关联

Closes #24 

## 自测

- [x] 本地 `npm run dev` 正常
- [x] 本地 `npm run lint` 通过
- [x] 本地 `npm run build` 通过

## 备注

<!-- 其他需要 Reviewer 关注的点 -->
