### PR TITLE
chore: 补充编辑器推荐扩展与 Tailwind 配置

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,10 @@
   "recommendations": [
     "Vue.volar",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
-  ]
+    "esbenp.prettier-vscode",
+    "bradlc.vscode-tailwindcss",
+    "vitest.explorer",
+    "EditorConfig.EditorConfig"
+  ],
+  "unwantedRecommendations": ["octref.vetur"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "files.associations": {
-    "LICENSE": "plaintext"
+    "LICENSE": "plaintext",
+    "*.css": "tailwindcss"
   },
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
@@ -9,5 +10,6 @@
   },
   "[vue]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  },
+  "tailwindCSS.experimental.configFile": "src/style.css"
 }


### PR DESCRIPTION
## Summary
- 扩展推荐：补上 Tailwind IntelliSense、Vitest、EditorConfig，并标记不推荐 Vetur
- 工作区设置：`*.css` 关联 Tailwind，指定 `src/style.css` 为 v4 入口

## Test plan
- [ ] 打开仓库后 Cursor/VS Code 提示安装推荐扩展
- [ ] Tailwind 类名有补全；Vetur 不被推荐


Made with [Cursor](https://cursor.com)