### PR TITLE
feat: 响应式布局与棋盘适配 (Issue 8)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,10 +1,11 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
 
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="theme-color" content="#f5f5f5" />
   <title>zen-gomoku</title>
 </head>
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -12,17 +12,53 @@ import GameBoard from './components/game/GameBoard.vue'
 
 <style scoped>
 .app {
-  min-height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  /* 固定视口高度，避免 min-height 在横屏下撑出可滚动区域导致裁切错觉 */
+  height: 100vh;
+  height: 100dvh;
+  display: grid;
+  place-items: center;
   background: #f5f5f5;
+  padding:
+    max(0.75rem, env(safe-area-inset-top, 0px))
+    max(0.75rem, env(safe-area-inset-right, 0px))
+    max(0.75rem, env(safe-area-inset-bottom, 0px))
+    max(0.75rem, env(safe-area-inset-left, 0px));
 }
+
 .app__board-wrap {
-  width: min(90vmin, 420px);
-  height: min(90vmin, 420px);
+  /*
+   * 宽高同一变量，强制正方形。
+   * min(可用宽, 可用高, 上限)：横屏吃高度、竖屏吃宽度。
+   * 只用 vw/vh，避免不支持 dvw 时整段 min() 失效。
+   */
+  --board-size: min(
+    560px,
+    calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 1.5rem),
+    calc(100vh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 1.5rem)
+  );
+  box-sizing: border-box;
+  width: var(--board-size);
+  height: var(--board-size);
+  max-width: 100%;
+  max-height: 100%;
   background: #dcb35c;
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+@supports (height: 100dvh) {
+  .app {
+    height: 100dvh;
+  }
+
+  .app__board-wrap {
+    --board-size: min(
+      560px,
+      calc(100dvw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 1.5rem),
+      calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px) - 1.5rem)
+    );
+  }
 }
 </style>

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -14,31 +14,46 @@ const canvasRef = ref<HTMLCanvasElement | null>(null)
 const lastClick = ref<{ row: number; col: number } | null>(null)
 const lastMessage = ref<string | null>(null)
 let resizeObserver: ResizeObserver | null = null
+let rafId = 0
 
 const BOARD_SIZE = gameStore.boardSize
 
-function getScale(): number {
+/** 容器可能因亚像素略非正方，取短边保证格子为正方形 */
+function getBoardSide(): number {
   const container = containerRef.value
   if (!container) return 0
   const w = container.clientWidth
   const h = container.clientHeight
   if (w <= 0 || h <= 0) return 0
-  return Math.min(w, h) / BOARD_SIZE
+  return Math.min(w, h)
+}
+
+function getScale(): number {
+  const side = getBoardSide()
+  return side > 0 ? side / BOARD_SIZE : 0
 }
 
 function draw() {
   const container = containerRef.value
   const canvas = canvasRef.value
   if (!container || !canvas) return
-  const w = container.clientWidth
-  const h = container.clientHeight
-  if (w <= 0 || h <= 0) return
+  const side = getBoardSide()
+  if (side <= 0) return
   const renderer = createBoardRenderer(canvas, {
-    containerWidth: w,
-    containerHeight: h,
+    containerWidth: side,
+    containerHeight: side,
   })
   renderer.drawBoard()
   renderer.drawPieces(board.value)
+}
+
+/** 合并同帧多次 resize / 横竖屏切换，避免频繁重绘 */
+function scheduleDraw() {
+  if (rafId) cancelAnimationFrame(rafId)
+  rafId = requestAnimationFrame(() => {
+    rafId = 0
+    draw()
+  })
 }
 
 function placeAt(row: number, col: number) {
@@ -70,13 +85,20 @@ function handleRestart() {
 onMounted(() => {
   draw()
   const container = containerRef.value
-  if (!container) return
-  resizeObserver = new ResizeObserver(() => draw())
-  resizeObserver.observe(container)
+  if (container) {
+    resizeObserver = new ResizeObserver(() => scheduleDraw())
+    resizeObserver.observe(container)
+  }
+  // 部分移动端横竖屏切换时容器尺寸更新略滞后，补一层兜底
+  window.addEventListener('orientationchange', scheduleDraw)
+  window.visualViewport?.addEventListener('resize', scheduleDraw)
 })
 
 onUnmounted(() => {
   resizeObserver?.disconnect()
+  window.removeEventListener('orientationchange', scheduleDraw)
+  window.visualViewport?.removeEventListener('resize', scheduleDraw)
+  if (rafId) cancelAnimationFrame(rafId)
 })
 </script>
 
@@ -110,19 +132,15 @@ onUnmounted(() => {
   position: relative;
   width: 100%;
   height: 100%;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  /* 触摸时避免整页橡皮筋滚动干扰落子 */
   touch-action: none;
+  overflow: hidden;
 }
 .game-board__canvas {
+  /* 铺满正方形容器；禁止只压单边导致格线被拉成长方形 */
   display: block;
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
   cursor: pointer;
-  /* 禁止双指缩放/滑动抢事件；微信内置浏览器同样生效 */
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
@@ -130,15 +148,19 @@ onUnmounted(() => {
 }
 .game-board__hint {
   position: absolute;
-  bottom: 0.25rem;
+  bottom: max(0.25rem, env(safe-area-inset-bottom, 0px));
   left: 50%;
   transform: translateX(-50%);
-  font-size: 0.75rem;
+  max-width: calc(100% - 0.5rem);
+  font-size: clamp(0.65rem, 2.4vmin, 0.8rem);
   color: #666;
   background: rgba(255, 255, 255, 0.9);
   padding: 0.15rem 0.5rem;
   border-radius: 4px;
   pointer-events: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .game-board__hint--error {
   color: #c00;
@@ -151,19 +173,20 @@ onUnmounted(() => {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: clamp(0.5rem, 3vmin, 1rem);
   background: rgba(0, 0, 0, 0.5);
   border-radius: 8px;
+  padding: 0.75rem;
 }
 .game-board__result {
   margin: 0;
-  font-size: 1.25rem;
+  font-size: clamp(1rem, 4.5vmin, 1.25rem);
   font-weight: 600;
   color: #fff;
 }
 .game-board__restart {
   padding: 0.5rem 1rem;
-  font-size: 0.9rem;
+  font-size: clamp(0.8rem, 3.2vmin, 0.9rem);
   color: #333;
   background: #fff;
   border: none;

--- a/src/renderer/BoardRenderer.test.ts
+++ b/src/renderer/BoardRenderer.test.ts
@@ -52,4 +52,19 @@ describe('createBoardRenderer', () => {
     renderer.drawBoard()
     expect(() => renderer.clear()).not.toThrow()
   })
+
+  it.skipIf(!hasCanvas)('applies devicePixelRatio to bitmap and fills container via CSS %', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+      devicePixelRatio: 2,
+    })
+    renderer.drawBoard()
+    expect(renderer.getSize()).toBe(300)
+    expect(canvas.width).toBe(600)
+    expect(canvas.height).toBe(600)
+    expect(canvas.style.width).toBe('100%')
+    expect(canvas.style.height).toBe('100%')
+  })
 })

--- a/src/renderer/BoardRenderer.ts
+++ b/src/renderer/BoardRenderer.ts
@@ -1,6 +1,7 @@
 /**
  * 棋盘渲染器：15×15 格线绘制，棋子绘制，响应式尺寸
  * scale = min(containerWidth, containerHeight) / 15
+ * 支持 devicePixelRatio，保证高分屏清晰
  * 暴露 drawBoard()、drawPiece()、drawPieces()、clear()
  */
 
@@ -14,10 +15,23 @@ const PIECE_RADIUS_RATIO = 0.45
 const WHITE_STROKE = '#999'
 
 export interface BoardRendererOptions {
-  /** 容器宽度（像素） */
+  /** 容器宽度（CSS 像素） */
   containerWidth: number
-  /** 容器高度（像素） */
+  /** 容器高度（CSS 像素） */
   containerHeight: number
+  /**
+   * 设备像素比；默认取 window.devicePixelRatio（测试可传入 1）
+   * 位图按 size * dpr 绘制，CSS 尺寸仍为 size，绘制坐标使用 CSS 像素
+   */
+  devicePixelRatio?: number
+}
+
+function resolveDpr(explicit?: number): number {
+  if (typeof explicit === 'number' && explicit > 0) return explicit
+  if (typeof window !== 'undefined' && window.devicePixelRatio > 0) {
+    return window.devicePixelRatio
+  }
+  return 1
 }
 
 /**
@@ -28,6 +42,7 @@ export function createBoardRenderer(
   options: BoardRendererOptions
 ) {
   const { containerWidth, containerHeight } = options
+  const dpr = resolveDpr(options.devicePixelRatio)
   const scale =
     Math.min(containerWidth, containerHeight) / BOARD_SIZE
   const size = BOARD_SIZE * scale
@@ -38,13 +53,27 @@ export function createBoardRenderer(
   const gridMax = offset + (BOARD_SIZE - 1) * scale
 
   return {
+    /** 当前格宽（CSS 像素），与坐标映射一致 */
+    getScale(): number {
+      return scale
+    },
+
+    /** 棋盘边长（CSS 像素） */
+    getSize(): number {
+      return size
+    },
+
     /** 绘制 15×15 格线（横竖各 15 根线，线仅在 offset 内收，不贴边） */
     drawBoard(): void {
       const ctx = canvas.getContext('2d')
       if (!ctx) return
 
-      canvas.width = size
-      canvas.height = size
+      canvas.width = Math.max(1, Math.round(size * dpr))
+      canvas.height = Math.max(1, Math.round(size * dpr))
+      // 由外层正方形容器用 100% 铺满，避免 inline px + max-width 只压单边造成拉伸
+      canvas.style.width = '100%'
+      canvas.style.height = '100%'
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
 
       ctx.strokeStyle = GRID_COLOR
       ctx.lineWidth = LINE_WIDTH
@@ -105,7 +134,7 @@ export function createBoardRenderer(
     clear(): void {
       const ctx = canvas.getContext('2d')
       if (!ctx) return
-      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      ctx.clearRect(0, 0, size, size)
     },
   }
 }

--- a/src/renderer/pointerMapper.test.ts
+++ b/src/renderer/pointerMapper.test.ts
@@ -3,13 +3,19 @@ import { pointerEventToLogical } from './pointerMapper.ts'
 import { BOARD_SIZE } from './coordMapper.ts'
 
 const scale = 28
-const bitmapSize = BOARD_SIZE * scale
+const cssSize = BOARD_SIZE * scale
 const offset = scale / 2
 
-function mockCanvas(displaySize: number, bitmap = bitmapSize): HTMLCanvasElement {
+function mockCanvas(
+  displaySize: number,
+  cssSizePx = displaySize,
+  bitmapSize = cssSizePx
+): HTMLCanvasElement {
   return {
-    width: bitmap,
-    height: bitmap,
+    width: bitmapSize,
+    height: bitmapSize,
+    clientWidth: cssSizePx,
+    clientHeight: cssSizePx,
     getBoundingClientRect: () => ({
       left: 10,
       top: 20,
@@ -25,24 +31,22 @@ function mockCanvas(displaySize: number, bitmap = bitmapSize): HTMLCanvasElement
 }
 
 describe('pointerEventToLogical', () => {
-  it('maps mouse-like client coords to (0,0) via display→bitmap', () => {
-    const canvas = mockCanvas(bitmapSize)
-    // 交点 (0,0) 在位图上为 (offset, offset)；1:1 显示时 client = left+offset, top+offset
+  it('maps mouse-like client coords to (0,0) via CSS pixels', () => {
+    const canvas = mockCanvas(cssSize)
     const point = pointerEventToLogical(10 + offset, 20 + offset, canvas, scale)
     expect(point).toEqual({ row: 0, col: 0 })
   })
 
   it('maps center intersection (7,7)', () => {
-    const canvas = mockCanvas(bitmapSize)
+    const canvas = mockCanvas(cssSize)
     const x = 10 + offset + 7 * scale
     const y = 20 + offset + 7 * scale
     expect(pointerEventToLogical(x, y, canvas, scale)).toEqual({ row: 7, col: 7 })
   })
 
-  it('handles CSS-scaled canvas (display ≠ bitmap)', () => {
-    const displaySize = bitmapSize / 2
-    const canvas = mockCanvas(displaySize)
-    // 显示坐标在交点 (7,7)：位图坐标 / 2
+  it('handles CSS-scaled canvas (display ≠ css layout size)', () => {
+    const displaySize = cssSize / 2
+    const canvas = mockCanvas(displaySize, cssSize)
     const displayX = (offset + 7 * scale) / 2
     const displayY = (offset + 7 * scale) / 2
     expect(
@@ -50,23 +54,26 @@ describe('pointerEventToLogical', () => {
     ).toEqual({ row: 7, col: 7 })
   })
 
+  it('handles high-DPR bitmap (width > clientWidth) without offset drift', () => {
+    const dpr = 2
+    const canvas = mockCanvas(cssSize, cssSize, cssSize * dpr)
+    const x = 10 + offset + 7 * scale
+    const y = 20 + offset + 7 * scale
+    expect(pointerEventToLogical(x, y, canvas, scale)).toEqual({ row: 7, col: 7 })
+  })
+
   it('returns null when pointer is outside canvas', () => {
-    const canvas = mockCanvas(bitmapSize)
+    const canvas = mockCanvas(cssSize)
     expect(pointerEventToLogical(5, 20, canvas, scale)).toBeNull()
     expect(pointerEventToLogical(10, 5, canvas, scale)).toBeNull()
     expect(
-      pointerEventToLogical(10 + bitmapSize + 1, 20 + offset, canvas, scale)
+      pointerEventToLogical(10 + cssSize + 1, 20 + offset, canvas, scale)
     ).toBeNull()
   })
 
   it('returns null when scale is invalid', () => {
-    const canvas = mockCanvas(bitmapSize)
+    const canvas = mockCanvas(cssSize)
     expect(pointerEventToLogical(10 + offset, 20 + offset, canvas, 0)).toBeNull()
     expect(pointerEventToLogical(10 + offset, 20 + offset, canvas, -1)).toBeNull()
-  })
-
-  it('returns null when canvas bitmap size is 0', () => {
-    const canvas = mockCanvas(100, 0)
-    expect(pointerEventToLogical(50, 50, canvas, scale)).toBeNull()
   })
 })

--- a/src/renderer/pointerMapper.ts
+++ b/src/renderer/pointerMapper.ts
@@ -1,6 +1,7 @@
 /**
  * 指针事件坐标 → 棋盘 (row, col)
- * Mouse / Touch / Pen 共用同一套 clientX/clientY → 位图 → 逻辑格点 路径
+ * Mouse / Touch / Pen 共用同一套 clientX/clientY → CSS 像素 → 逻辑格点 路径
+ * （与 BoardRenderer 的 CSS 像素绘制坐标系一致，兼容 devicePixelRatio）
  */
 
 import { createCoordMapper, type LogicalPoint } from './coordMapper.ts'
@@ -16,7 +17,6 @@ export function pointerEventToLogical(
   scale: number
 ): LogicalPoint | null {
   if (scale <= 0) return null
-  if (canvas.width <= 0 || canvas.height <= 0) return null
 
   const rect = canvas.getBoundingClientRect()
   if (rect.width <= 0 || rect.height <= 0) return null
@@ -32,7 +32,12 @@ export function pointerEventToLogical(
     return null
   }
 
-  const bitmapX = displayX * (canvas.width / rect.width)
-  const bitmapY = displayY * (canvas.height / rect.height)
-  return createCoordMapper(scale).pixelToLogical(bitmapX, bitmapY)
+  // 使用 CSS 像素坐标系（clientWidth），避免位图尺寸含 DPR 时映射偏移
+  const cssWidth = canvas.clientWidth || rect.width
+  const cssHeight = canvas.clientHeight || rect.height
+  if (cssWidth <= 0 || cssHeight <= 0) return null
+
+  const cssX = displayX * (cssWidth / rect.width)
+  const cssY = displayY * (cssHeight / rect.height)
+  return createCoordMapper(scale).pixelToLogical(cssX, cssY)
 }

--- a/src/style.css
+++ b/src/style.css
@@ -15,72 +15,28 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
-a:hover {
-  color: #535bf2;
+html,
+body,
+#app {
+  margin: 0;
+  width: 100%;
+  height: 100%;
 }
 
 body {
-  margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-
-button:hover {
-  border-color: #646cff;
-}
-
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-.card {
-  padding: 2em;
-}
-
-#app {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  overflow: hidden;
 }
 
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
     background-color: #ffffff;
-  }
-
-  a:hover {
-    color: #747bff;
-  }
-
-  button {
-    background-color: #f9f9f9;
   }
 }


### PR DESCRIPTION
## Summary
- 棋盘宽高使用同一 `--board-size`（可用宽/高取 min），横竖屏均保持正方形且不裁切
- Canvas 铺满正方形容器，按 DPR 绘制；落点映射改走 CSS 像素
- 清理全局 `#app` padding，补充安全区与横竖屏重绘兜底

## 关联
Closes #26

## Test plan
- [ ] iPhone SE 竖屏：格子为正方形，完整可见
- [ ] iPhone SE 横屏：棋盘完整落入视口，不被裁切
- [ ] 桌面缩放窗口：棋盘随视口重算并重绘
- [ ] `npm run test` / `lint` / `build` 通过


Made with [Cursor](https://cursor.com)