### PR TITLE
fix: 布局防跳与最近落子标记 (Closes #40, #41)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,8 +36,8 @@ import GameModeBar from './components/game/GameModeBar.vue'
 }
 
 .app__board-wrap {
-  /* 预留上下工具条高度 */
-  --toolbar-reserve: 7.25rem;
+  /* 预留模式栏 + 记录栏 + 复盘栏（含固定占位） */
+  --toolbar-reserve: 9.5rem;
   --board-size: min(
     560px,
     calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 1.5rem),

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -53,6 +53,11 @@ function draw() {
   })
   renderer.drawBoard()
   renderer.drawPieces(displayBoard.value)
+  const markIndex = displayHistoryIndex.value - 1
+  if (markIndex >= 0) {
+    const last = history.value[markIndex]
+    if (last) renderer.drawLastMoveMark(last.row, last.col)
+  }
 }
 
 function scheduleDraw() {

--- a/src/components/game/GameModeBar.vue
+++ b/src/components/game/GameModeBar.vue
@@ -11,35 +11,52 @@ function toggleVsAi() {
 </script>
 
 <template>
+  <!-- 三列网格：按钮居中，状态文案放右侧，不挤歪按钮 -->
   <div class="mode-bar">
-    <button
-      type="button"
-      class="mode-bar__btn"
-      :class="{ 'mode-bar__btn--active': !vsAi }"
-      @click="gameStore.setVsAi(false)"
+    <div class="mode-bar__spacer" aria-hidden="true" />
+    <div class="mode-bar__btns">
+      <button
+        type="button"
+        class="mode-bar__btn"
+        :class="{ 'mode-bar__btn--active': !vsAi }"
+        @click="gameStore.setVsAi(false)"
+      >
+        人人
+      </button>
+      <button
+        type="button"
+        class="mode-bar__btn"
+        :class="{ 'mode-bar__btn--active': vsAi }"
+        @click="toggleVsAi"
+      >
+        人机（你执黑）
+      </button>
+    </div>
+    <span
+      class="mode-bar__status"
+      :class="{ 'mode-bar__status--idle': !(vsAi && aiThinking) }"
     >
-      人人
-    </button>
-    <button
-      type="button"
-      class="mode-bar__btn"
-      :class="{ 'mode-bar__btn--active': vsAi }"
-      @click="toggleVsAi"
-    >
-      人机（你执黑）
-    </button>
-    <span v-if="vsAi && aiThinking" class="mode-bar__status">AI 思考中…</span>
+      AI 思考中…
+    </span>
   </div>
 </template>
 
 <style scoped>
 .mode-bar {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  column-gap: 0.4rem;
+  width: min(100%, 560px);
+}
+.mode-bar__spacer {
+  min-width: 0;
+}
+.mode-bar__btns {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
   justify-content: center;
   gap: 0.4rem;
-  width: min(100%, 560px);
 }
 .mode-bar__btn {
   padding: 0.35rem 0.7rem;
@@ -59,7 +76,12 @@ function toggleVsAi() {
   border-color: #555;
 }
 .mode-bar__status {
+  justify-self: start;
   font-size: 0.75rem;
   color: #666;
+  white-space: nowrap;
+}
+.mode-bar__status--idle {
+  visibility: hidden;
 }
 </style>

--- a/src/components/game/GameRecordBar.vue
+++ b/src/components/game/GameRecordBar.vue
@@ -90,13 +90,16 @@ watch(status, (next, prev) => {
         @change="handleFileChange"
       />
     </div>
+    <!-- 固定占位，避免提示显隐导致棋盘上下跳动 -->
     <p
-      v-if="message"
       class="record-bar__msg"
-      :class="{ 'record-bar__msg--error': messageIsError }"
+      :class="{
+        'record-bar__msg--error': messageIsError,
+        'record-bar__msg--empty': !message,
+      }"
       aria-live="polite"
     >
-      {{ message }}
+      {{ message || '\u00a0' }}
     </p>
   </div>
 </template>
@@ -132,8 +135,14 @@ watch(status, (next, prev) => {
 }
 .record-bar__msg {
   margin: 0;
+  min-height: 1.15em;
   font-size: 0.75rem;
+  line-height: 1.15;
   color: #555;
+  text-align: center;
+}
+.record-bar__msg--empty {
+  visibility: hidden;
 }
 .record-bar__msg--error {
   color: #c00;

--- a/src/components/game/GameReplayBar.vue
+++ b/src/components/game/GameReplayBar.vue
@@ -36,13 +36,19 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div v-if="canReplay" class="replay-bar" aria-label="复盘控制">
+  <!-- 始终占位，无棋谱时隐藏可见性，避免复盘条弹出导致棋盘跳动 -->
+  <div
+    class="replay-bar"
+    :class="{ 'replay-bar--idle': !canReplay }"
+    aria-label="复盘控制"
+    :aria-hidden="!canReplay"
+  >
     <div class="replay-bar__actions">
       <button
         type="button"
         class="replay-bar__btn"
         title="开头"
-        :disabled="displayHistoryIndex <= 0"
+        :disabled="!canReplay || displayHistoryIndex <= 0"
         @click="gameStore.goToStart()"
       >
         |◀
@@ -51,7 +57,7 @@ onUnmounted(() => {
         type="button"
         class="replay-bar__btn"
         title="后退一手"
-        :disabled="displayHistoryIndex <= 0"
+        :disabled="!canReplay || displayHistoryIndex <= 0"
         @click="gameStore.stepBack()"
       >
         ◀
@@ -60,6 +66,7 @@ onUnmounted(() => {
         type="button"
         class="replay-bar__btn replay-bar__btn--primary"
         :title="isReplayPlaying ? '暂停' : '播放'"
+        :disabled="!canReplay"
         @click="gameStore.toggleReplay()"
       >
         {{ isReplayPlaying ? '暂停' : '播放' }}
@@ -68,7 +75,7 @@ onUnmounted(() => {
         type="button"
         class="replay-bar__btn"
         title="前进一手"
-        :disabled="isAtLiveEdge"
+        :disabled="!canReplay || isAtLiveEdge"
         @click="gameStore.stepForward()"
       >
         ▶
@@ -77,7 +84,7 @@ onUnmounted(() => {
         type="button"
         class="replay-bar__btn"
         title="最新"
-        :disabled="isAtLiveEdge"
+        :disabled="!canReplay || isAtLiveEdge"
         @click="gameStore.goToEnd()"
       >
         ▶|
@@ -97,6 +104,11 @@ onUnmounted(() => {
   align-items: center;
   gap: 0.25rem;
   width: min(100%, 560px);
+  min-height: 3.4rem;
+}
+.replay-bar--idle {
+  visibility: hidden;
+  pointer-events: none;
 }
 .replay-bar__actions {
   display: flex;

--- a/src/renderer/BoardRenderer.test.ts
+++ b/src/renderer/BoardRenderer.test.ts
@@ -6,7 +6,7 @@ const hasCanvas =
   typeof globalThis.document.createElement === 'function'
 
 describe('createBoardRenderer', () => {
-  it.skipIf(!hasCanvas)('returns drawBoard, drawPiece, drawPieces, clear', () => {
+  it.skipIf(!hasCanvas)('returns drawBoard, drawPiece, drawPieces, drawLastMoveMark, clear', () => {
     const canvas = document.createElement('canvas')
     const renderer = createBoardRenderer(canvas, {
       containerWidth: 300,
@@ -15,6 +15,7 @@ describe('createBoardRenderer', () => {
     expect(typeof renderer.drawBoard).toBe('function')
     expect(typeof renderer.drawPiece).toBe('function')
     expect(typeof renderer.drawPieces).toBe('function')
+    expect(typeof renderer.drawLastMoveMark).toBe('function')
     expect(typeof renderer.clear).toBe('function')
   })
 
@@ -41,6 +42,18 @@ describe('createBoardRenderer', () => {
     board[14]![14] = 2
     board[7]![7] = 1
     expect(() => renderer.drawPieces(board)).not.toThrow()
+  })
+
+  it.skipIf(!hasCanvas)('drawLastMoveMark does not throw', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    renderer.drawBoard()
+    renderer.drawPiece(7, 7, 1)
+    expect(() => renderer.drawLastMoveMark(7, 7)).not.toThrow()
+    expect(() => renderer.drawLastMoveMark(-1, 0)).not.toThrow()
   })
 
   it.skipIf(!hasCanvas)('clear does not throw', () => {

--- a/src/renderer/BoardRenderer.ts
+++ b/src/renderer/BoardRenderer.ts
@@ -2,7 +2,7 @@
  * 棋盘渲染器：15×15 格线绘制，棋子绘制，响应式尺寸
  * scale = min(containerWidth, containerHeight) / 15
  * 支持 devicePixelRatio，保证高分屏清晰
- * 暴露 drawBoard()、drawPiece()、drawPieces()、clear()
+ * 暴露 drawBoard()、drawPiece()、drawPieces()、drawLastMoveMark()、clear()
  */
 
 const BOARD_SIZE = 15
@@ -13,6 +13,13 @@ export type PieceColor = 1 | 2
 const PIECE_RADIUS_RATIO = 0.45
 /** 白子描边：浅灰，在浅色棋盘上可见且不突兀 */
 const WHITE_STROKE = '#999'
+/**
+ * 最近落子标记：常见五子棋做法为统一红色强调（空心小圆），
+ * 黑白子上都醒目，避免「反色十字」在白子上发脏
+ */
+const LAST_MOVE_MARK = '#e53935'
+const LAST_MOVE_RADIUS_RATIO = 0.15
+const LAST_MOVE_LINE_RATIO = 0.055
 
 export interface BoardRendererOptions {
   /** 容器宽度（CSS 像素） */
@@ -128,6 +135,23 @@ export function createBoardRenderer(
           }
         }
       }
+    },
+
+    /**
+     * 在最近落子交点绘制红色空心小圆（黑白子通用，行业常见做法）
+     */
+    drawLastMoveMark(row: number, col: number): void {
+      if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) return
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      const centerX = offset + col * scale
+      const centerY = offset + row * scale
+      const radius = scale * LAST_MOVE_RADIUS_RATIO
+      ctx.strokeStyle = LAST_MOVE_MARK
+      ctx.lineWidth = Math.max(1.5, scale * LAST_MOVE_LINE_RATIO)
+      ctx.beginPath()
+      ctx.arc(centerX, centerY, radius, 0, Math.PI * 2)
+      ctx.stroke()
     },
 
     /** 清空画布 */


### PR DESCRIPTION
## Summary
- 状态提示、复盘条、「AI 思考中」改为固定占位，消除开局/终局棋盘上下跳动
- 最近一手绘制红色空心小圆标记（复盘跟随展示末步）
- 人人/人机按钮用三列网格居中，状态文案不再挤歪按钮

Closes #40
Closes #41

## Test plan
- [ ] 空棋盘 → 落子 → 终局自动保存：棋盘位置无明显跳动
- [ ] 复盘条始终占位；无棋谱时不可点、不可见
- [ ] 最近一手有红色空心圆；复盘前进/后退标记跟随
- [ ] 模式栏按钮视觉居中；AI 思考时右侧出现文案且按钮不偏移
- [ ] `npm run test` / `npm run lint` / `npm run build` 通过


Made with [Cursor](https://cursor.com)