### PR TITLE
feat: 星位、天元开局与人机先后手 (Closes #46)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -36,8 +36,8 @@ import GameModeBar from './components/game/GameModeBar.vue'
 }
 
 .app__board-wrap {
-  /* 预留模式栏(含对手选择) + 记录栏 + 复盘栏 */
-  --toolbar-reserve: 11rem;
+  /* 预留模式栏(含先后/对手) + 记录栏 + 复盘栏 */
+  --toolbar-reserve: 11.5rem;
   --board-size: min(
     560px,
     calc(100vw - env(safe-area-inset-left, 0px) - env(safe-area-inset-right, 0px) - 1.5rem),

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -15,6 +15,7 @@ const {
   isAtLiveEdge,
   vsAi,
   aiThinking,
+  aiPlayer,
 } = storeToRefs(gameStore)
 
 const containerRef = ref<HTMLDivElement | null>(null)
@@ -139,7 +140,7 @@ onUnmounted(() => {
         <template v-else>
           <span>
             当前：{{ currentPlayer === 1 ? '黑' : '白' }}方
-            <template v-if="vsAi">（{{ currentPlayer === 1 ? '你' : 'AI' }}）</template>
+            <template v-if="vsAi">（{{ currentPlayer === aiPlayer ? 'AI' : '你' }}）</template>
           </span>
           <span v-if="lastClick !== null"> · 上次 ({{ lastClick.row }}, {{ lastClick.col }})</span>
         </template>

--- a/src/components/game/GameModeBar.vue
+++ b/src/components/game/GameModeBar.vue
@@ -7,7 +7,7 @@ import {
 } from '../../stores'
 
 const gameStore = useGameStore()
-const { vsAi, aiThinking, aiDifficulty } = storeToRefs(gameStore)
+const { vsAi, aiThinking, aiDifficulty, humanFirst } = storeToRefs(gameStore)
 
 function toggleVsAi() {
   gameStore.setVsAi(!vsAi.value)
@@ -16,6 +16,11 @@ function toggleVsAi() {
 function onDifficultyChange(event: Event) {
   const value = (event.target as HTMLSelectElement).value as AiDifficulty
   gameStore.setAiDifficulty(value)
+}
+
+function onFirstChange(event: Event) {
+  const value = (event.target as HTMLSelectElement).value
+  gameStore.setHumanFirst(value === 'human')
 }
 </script>
 
@@ -38,7 +43,7 @@ function onDifficultyChange(event: Event) {
           :class="{ 'mode-bar__btn--active': vsAi }"
           @click="toggleVsAi"
         >
-          人机（你执黑）
+          人机
         </button>
       </div>
       <span
@@ -49,12 +54,28 @@ function onDifficultyChange(event: Event) {
       </span>
     </div>
 
-    <div v-if="vsAi" class="mode-bar__difficulty">
+    <div
+      class="mode-bar__options"
+      :class="{ 'mode-bar__options--idle': !vsAi }"
+      :aria-hidden="!vsAi"
+    >
+      <label class="mode-bar__diff-label" for="ai-first">先后</label>
+      <select
+        id="ai-first"
+        class="mode-bar__select"
+        :value="humanFirst ? 'human' : 'ai'"
+        :disabled="!vsAi"
+        @change="onFirstChange"
+      >
+        <option value="human">你先（执黑）</option>
+        <option value="ai">AI 先（执黑）</option>
+      </select>
       <label class="mode-bar__diff-label" for="ai-difficulty">对手</label>
       <select
         id="ai-difficulty"
         class="mode-bar__select"
         :value="aiDifficulty"
+        :disabled="!vsAi"
         @change="onDifficultyChange"
       >
         <option
@@ -65,11 +86,6 @@ function onDifficultyChange(event: Event) {
           {{ opt.name }}
         </option>
       </select>
-    </div>
-    <!-- 人人模式占位，避免显隐跳动 -->
-    <div v-else class="mode-bar__difficulty mode-bar__difficulty--idle" aria-hidden="true">
-      <span class="mode-bar__diff-label">对手</span>
-      <span class="mode-bar__select-ph">猪八戒</span>
     </div>
   </div>
 </template>
@@ -124,15 +140,17 @@ function onDifficultyChange(event: Event) {
 .mode-bar__status--idle {
   visibility: hidden;
 }
-.mode-bar__difficulty {
+.mode-bar__options {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   gap: 0.4rem;
   min-height: 1.75rem;
 }
-.mode-bar__difficulty--idle {
+.mode-bar__options--idle {
   visibility: hidden;
+  pointer-events: none;
 }
 .mode-bar__diff-label {
   font-size: 0.75rem;
@@ -147,10 +165,7 @@ function onDifficultyChange(event: Event) {
   border-radius: 6px;
   cursor: pointer;
 }
-.mode-bar__select-ph {
-  display: inline-block;
-  min-width: 5rem;
-  padding: 0.25rem 0.45rem;
-  font-size: 0.8rem;
+.mode-bar__select:disabled {
+  cursor: not-allowed;
 }
 </style>

--- a/src/renderer/BoardRenderer.test.ts
+++ b/src/renderer/BoardRenderer.test.ts
@@ -6,6 +6,15 @@ const hasCanvas =
   typeof globalThis.document.createElement === 'function'
 
 describe('createBoardRenderer', () => {
+  it.skipIf(!hasCanvas)('drawBoard draws without throw (includes star points)', () => {
+    const canvas = document.createElement('canvas')
+    const renderer = createBoardRenderer(canvas, {
+      containerWidth: 300,
+      containerHeight: 300,
+    })
+    expect(() => renderer.drawBoard()).not.toThrow()
+  })
+
   it.skipIf(!hasCanvas)('returns drawBoard, drawPiece, drawPieces, drawLastMoveMark, clear', () => {
     const canvas = document.createElement('canvas')
     const renderer = createBoardRenderer(canvas, {

--- a/src/renderer/BoardRenderer.ts
+++ b/src/renderer/BoardRenderer.ts
@@ -8,6 +8,16 @@
 const BOARD_SIZE = 15
 const GRID_COLOR = '#333'
 const LINE_WIDTH = 1
+/** 15×15 连珠盘五星（0-based）：天元 + 四角 */
+export const STAR_POINTS: ReadonlyArray<readonly [number, number]> = [
+  [3, 3],
+  [3, 11],
+  [7, 7],
+  [11, 3],
+  [11, 11],
+]
+const STAR_COLOR = '#3d2914'
+const STAR_RADIUS_RATIO = 0.09
 /** 棋子颜色：1 黑 2 白，与 store board 约定一致 */
 export type PieceColor = 1 | 2
 const PIECE_RADIUS_RATIO = 0.45
@@ -95,6 +105,17 @@ export function createBoardRenderer(
         ctx.moveTo(gridMin, p)
         ctx.lineTo(gridMax, p)
         ctx.stroke()
+      }
+
+      // 星位：格线之上、棋子之下
+      const starR = Math.max(2, scale * STAR_RADIUS_RATIO)
+      ctx.fillStyle = STAR_COLOR
+      for (const [row, col] of STAR_POINTS) {
+        const x = offset + col * scale
+        const y = offset + row * scale
+        ctx.beginPath()
+        ctx.arc(x, y, starR, 0, Math.PI * 2)
+        ctx.fill()
       }
     },
 

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -1,4 +1,4 @@
-export { createBoardRenderer } from './BoardRenderer.ts'
+export { createBoardRenderer, STAR_POINTS } from './BoardRenderer.ts'
 export type { BoardRendererOptions, PieceColor } from './BoardRenderer.ts'
 export { createCoordMapper, BOARD_SIZE } from './coordMapper.ts'
 export type { LogicalPoint, PixelPoint } from './coordMapper.ts'

--- a/src/stores/game.test.ts
+++ b/src/stores/game.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
-import { useGameStore } from './game'
+import { useGameStore, TENGEN_ROW, TENGEN_COL } from './game'
 
 describe('useGameStore', () => {
   beforeEach(() => {
@@ -16,13 +16,30 @@ describe('useGameStore', () => {
     expect(store.canPlay).toBe(true)
   })
 
+  it('placeStone: first move must be tengen', () => {
+    const store = useGameStore()
+    const bad = store.placeStone(0, 0)
+    expect(bad.success).toBe(false)
+    expect((bad as { message: string }).message).toBe('第一步请下在天元')
+    expect(store.history).toHaveLength(0)
+
+    const ok = store.placeStone(TENGEN_ROW, TENGEN_COL)
+    expect(ok.success).toBe(true)
+    expect(store.board[TENGEN_ROW]![TENGEN_COL]).toBe(1)
+    expect(store.currentPlayer).toBe(2)
+  })
+
   it('placeStone: success updates board, history, and switches player', () => {
     const store = useGameStore()
-    const r = store.placeStone(0, 0)
+    const r = store.placeStone(TENGEN_ROW, TENGEN_COL)
     expect(r.success).toBe(true)
-    expect(store.board[0]![0]).toBe(1)
+    expect(store.board[TENGEN_ROW]![TENGEN_COL]).toBe(1)
     expect(store.history).toHaveLength(1)
-    expect(store.history[0]).toEqual({ row: 0, col: 0, player: 1 })
+    expect(store.history[0]).toEqual({
+      row: TENGEN_ROW,
+      col: TENGEN_COL,
+      player: 1,
+    })
     expect(store.currentPlayer).toBe(2)
 
     const r2 = store.placeStone(1, 1)
@@ -34,9 +51,9 @@ describe('useGameStore', () => {
 
   it('placeStone: reject duplicate move and do not push history', () => {
     const store = useGameStore()
-    store.placeStone(0, 0)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     const len = store.history.length
-    const result = store.placeStone(0, 0)
+    const result = store.placeStone(TENGEN_ROW, TENGEN_COL)
     expect(result.success).toBe(false)
     expect((result as { message: string }).message).toBe('该位置已有棋子')
     expect(store.history).toHaveLength(len)
@@ -52,22 +69,23 @@ describe('useGameStore', () => {
 
   it('placeStone: after five in a row updates status to black_win', () => {
     const store = useGameStore()
-    store.placeStone(7, 0)
-    store.placeStone(0, 0) // white
-    store.placeStone(7, 1)
+    // 天元开局后，在第 7 行向左连成五子：7,3..7,7
+    store.placeStone(7, 7)
+    store.placeStone(0, 0)
+    store.placeStone(7, 6)
     store.placeStone(0, 1)
-    store.placeStone(7, 2)
+    store.placeStone(7, 5)
     store.placeStone(0, 2)
-    store.placeStone(7, 3)
+    store.placeStone(7, 4)
     store.placeStone(0, 3)
-    store.placeStone(7, 4) // black fifth in a row
+    store.placeStone(7, 3)
     expect(store.status).toBe('black_win')
     expect(store.canPlay).toBe(false)
   })
 
   it('resetGame: clears board, history, black first', () => {
     const store = useGameStore()
-    store.placeStone(0, 0)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     store.placeStone(1, 1)
     store.resetGame()
     expect(store.board.every((row) => row.every((c) => c === 0))).toBe(true)
@@ -95,23 +113,23 @@ describe('useGameStore', () => {
     const { createMemoryStorage } = await import('../storage')
     const storage = createMemoryStorage()
     const store = useGameStore()
-    store.placeStone(3, 3)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     expect(store.saveToStorage(storage).success).toBe(true)
     store.resetGame()
     expect(store.loadFromStorage(storage).success).toBe(true)
-    expect(store.board[3]![3]).toBe(1)
+    expect(store.board[TENGEN_ROW]![TENGEN_COL]).toBe(1)
     expect(store.history).toHaveLength(1)
   })
 
   it('replay: stepBack/Forward does not mutate history', () => {
     const store = useGameStore()
-    store.placeStone(0, 0)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     store.placeStone(1, 1)
     expect(store.displayHistoryIndex).toBe(2)
     store.stepBack()
     expect(store.displayHistoryIndex).toBe(1)
     expect(store.history).toHaveLength(2)
-    expect(store.displayBoard[0]![0]).toBe(1)
+    expect(store.displayBoard[TENGEN_ROW]![TENGEN_COL]).toBe(1)
     expect(store.displayBoard[1]![1]).toBe(0)
     expect(store.canPlay).toBe(false)
     store.stepForward()
@@ -122,7 +140,7 @@ describe('useGameStore', () => {
 
   it('replay: placeStone rejected while scrubbing', () => {
     const store = useGameStore()
-    store.placeStone(0, 0)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     store.placeStone(1, 1)
     store.goToStart()
     const result = store.placeStone(2, 2)
@@ -132,7 +150,7 @@ describe('useGameStore', () => {
 
   it('replay: tickReplay advances and stops at end', () => {
     const store = useGameStore()
-    store.placeStone(0, 0)
+    store.placeStone(TENGEN_ROW, TENGEN_COL)
     store.placeStone(1, 1)
     store.goToStart()
     store.playReplay()
@@ -154,13 +172,37 @@ describe('useGameStore', () => {
       },
     })
     store.setVsAi(true)
-    expect(store.placeStone(0, 0).success).toBe(true)
+    expect(store.placeStone(TENGEN_ROW, TENGEN_COL).success).toBe(true)
     expect(store.aiThinking).toBe(true)
     await vi.advanceTimersByTimeAsync(300)
     await Promise.resolve()
     expect(store.board[1]![1]).toBe(2)
     expect(store.currentPlayer).toBe(1)
     expect(store.aiThinking).toBe(false)
+    vi.useRealTimers()
+  })
+
+  it('vsAi AI first: AI places tengen as black', async () => {
+    vi.useFakeTimers()
+    const store = useGameStore()
+    store.setAgent({
+      name: 'test',
+      async getNextMove(board) {
+        // 空盘应下天元；此处直接返回天元验证接线
+        void board
+        return { row: TENGEN_ROW, col: TENGEN_COL }
+      },
+    })
+    store.setHumanFirst(false)
+    store.setVsAi(true)
+    expect(store.aiPlayer).toBe(1)
+    expect(store.canPlay).toBe(false)
+    expect(store.aiThinking).toBe(true)
+    await vi.advanceTimersByTimeAsync(300)
+    await Promise.resolve()
+    expect(store.board[TENGEN_ROW]![TENGEN_COL]).toBe(1)
+    expect(store.currentPlayer).toBe(2)
+    expect(store.canPlay).toBe(true)
     vi.useRealTimers()
   })
 

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -27,6 +27,9 @@ import {
 } from '../ai'
 
 const BOARD_SIZE = 15
+/** 天元（15×15 中心，0-based） */
+export const TENGEN_ROW = 7
+export const TENGEN_COL = 7
 /** 自动回放间隔（ms） */
 export const REPLAY_INTERVAL_MS = 600
 /** AI 落子前短延迟，便于看清人下完的一手 */
@@ -34,9 +37,6 @@ export const AI_MOVE_DELAY_MS = 280
 
 export type Player = 1 | 2
 export type GameStatus = 'playing' | 'black_win' | 'white_win' | 'draw'
-
-/** 人机模式下 AI 执白 */
-export const AI_PLAYER: Player = 2
 
 export interface HistoryEntry {
   row: number
@@ -61,13 +61,18 @@ export const useGameStore = defineStore('game', () => {
   const displayHistoryIndex = ref(0)
   /** 是否正在自动播放复盘 */
   const isReplayPlaying = ref(false)
-  /** 人机对战（人黑 AI 白） */
+  /** 人机对战 */
   const vsAi = ref(false)
   const aiThinking = ref(false)
+  /** true：人类执黑先手；false：AI 执黑先手 */
+  const humanFirst = ref(true)
   /** 对手等级：沙和尚～唐僧 */
   const aiDifficulty = ref<AiDifficulty>(DEFAULT_AI_DIFFICULTY)
   let agent: IAgent = createAgentForDifficulty(DEFAULT_AI_DIFFICULTY, BOARD_SIZE)
   let aiToken = 0
+
+  /** 人机下 AI 所执颜色 */
+  const aiPlayer = computed<Player>(() => (humanFirst.value ? 2 : 1))
 
   const isAtLiveEdge = computed(
     () => displayHistoryIndex.value >= history.value.length
@@ -79,7 +84,7 @@ export const useGameStore = defineStore('game', () => {
       status.value === 'playing' &&
       isAtLiveEdge.value &&
       !aiThinking.value &&
-      !(vsAi.value && currentPlayer.value === AI_PLAYER)
+      !(vsAi.value && currentPlayer.value === aiPlayer.value)
   )
 
   const canReplay = computed(() => history.value.length > 0)
@@ -161,11 +166,17 @@ export const useGameStore = defineStore('game', () => {
     if (!isAtLiveEdge.value) {
       return { success: false, message: '请先回到最新局面再落子' }
     }
-    if (vsAi.value && currentPlayer.value === AI_PLAYER && !aiThinking.value) {
+    if (vsAi.value && currentPlayer.value === aiPlayer.value && !aiThinking.value) {
       return { success: false, message: '现在是 AI 回合' }
     }
     if (row < 0 || row >= BOARD_SIZE || col < 0 || col >= BOARD_SIZE) {
       return { success: false, message: '落子超出棋盘' }
+    }
+    if (
+      history.value.length === 0 &&
+      (row !== TENGEN_ROW || col !== TENGEN_COL)
+    ) {
+      return { success: false, message: '第一步请下在天元' }
     }
     const rowData = board.value[row]
     if (!rowData || rowData[col] !== 0) {
@@ -189,7 +200,7 @@ export const useGameStore = defineStore('game', () => {
     if (!vsAi.value) return
     if (status.value !== 'playing') return
     if (!isAtLiveEdge.value) return
-    if (currentPlayer.value !== AI_PLAYER) return
+    if (currentPlayer.value !== aiPlayer.value) return
     if (aiThinking.value) return
     const token = ++aiToken
     void runAiMove(token)
@@ -201,7 +212,7 @@ export const useGameStore = defineStore('game', () => {
       await new Promise((r) => setTimeout(r, AI_MOVE_DELAY_MS))
       if (token !== aiToken) return
       if (!vsAi.value || status.value !== 'playing') return
-      if (currentPlayer.value !== AI_PLAYER) return
+      if (currentPlayer.value !== aiPlayer.value) return
       const snapshot = board.value.map((row) => row.slice())
       const move = await agent.getNextMove(snapshot)
       if (token !== aiToken) return
@@ -221,6 +232,13 @@ export const useGameStore = defineStore('game', () => {
     if (enabled) {
       scheduleAiMove()
     }
+  }
+
+  /** 切换先后手会清空当前对局并按新设置开局 */
+  function setHumanFirst(next: boolean): void {
+    if (humanFirst.value === next) return
+    humanFirst.value = next
+    resetGame()
   }
 
   function setAiDifficulty(next: AiDifficulty): void {
@@ -246,6 +264,7 @@ export const useGameStore = defineStore('game', () => {
     history.value = []
     status.value = 'playing'
     displayHistoryIndex.value = 0
+    scheduleAiMove()
   }
 
   function exportRecord(): GameRecord {
@@ -320,9 +339,12 @@ export const useGameStore = defineStore('game', () => {
     vsAi,
     aiThinking,
     aiDifficulty,
+    humanFirst,
+    aiPlayer,
     placeStone,
     resetGame,
     setVsAi,
+    setHumanFirst,
     setAiDifficulty,
     setAgent,
     exportRecord,

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,8 +1,9 @@
 export {
   useGameStore,
   REPLAY_INTERVAL_MS,
-  AI_PLAYER,
   AI_MOVE_DELAY_MS,
+  TENGEN_ROW,
+  TENGEN_COL,
 } from './game'
 export type { Player, GameStatus, HistoryEntry, ActionResult } from './game'
 export {


### PR DESCRIPTION
## Summary
- 15×15 棋盘绘制标准五星（天元 + 四角）
- 空盘首手必须落在天元，否则提示「第一步请下在天元」
- 人机模式可选「你先（执黑）」或「AI 先（执黑）」；切换会清空重开；AI 先手自动下天元

Closes #46

## Test plan
- [ ] 棋盘可见 5 个星位，居中对称
- [ ] 首手点非天元失败并有提示；天元可落
- [ ] 人机「你先」：人类执黑，AI 执白应手
- [ ] 人机「AI 先」：开局 AI 自动下天元，人类执白
- [ ] `npm run test` / `npm run lint` / `npm run build` 通过


Made with [Cursor](https://cursor.com)