### PR TITLE
fix: 落子音效时有时无

### DIFF
--- a/src/audio/index.ts
+++ b/src/audio/index.ts
@@ -1,6 +1,7 @@
 export {
   playPlaceSound,
   preloadPlaceSound,
+  unlockPlaceSound,
   isPlaceSoundEnabled,
   setPlaceSoundEnabled,
   togglePlaceSoundEnabled,

--- a/src/audio/placeSound.test.ts
+++ b/src/audio/placeSound.test.ts
@@ -4,6 +4,7 @@ import {
   setPlaceSoundEnabled,
   togglePlaceSoundEnabled,
   playPlaceSound,
+  unlockPlaceSound,
 } from './placeSound'
 
 describe('placeSound', () => {
@@ -30,6 +31,11 @@ describe('placeSound', () => {
 
   it('playPlaceSound does not throw when muted', () => {
     setPlaceSoundEnabled(false)
+    expect(() => playPlaceSound()).not.toThrow()
+  })
+
+  it('unlockPlaceSound and playPlaceSound do not throw', () => {
+    expect(() => unlockPlaceSound()).not.toThrow()
     expect(() => playPlaceSound()).not.toThrow()
   })
 })

--- a/src/audio/placeSound.ts
+++ b/src/audio/placeSound.ts
@@ -2,14 +2,19 @@
  * 落子音效
  * 素材：`place-stone-original.ogg` — CC0（freesound j1987/put_item，经 appgurueu/go）
  * 播放略加速，缩短拖尾、减轻沉闷感
+ *
+ * 可靠性：
+ * - 每次播放 clone 节点，避免单例 Audio 连点 / 人机连下时 play() 被打断而静默失败
+ * - 在用户手势中 unlock，避免 AI 先手时被浏览器自动播放策略拦截
  */
 
 import placeStoneUrl from '../assets/audio/place-stone-original.ogg'
 
 const STORAGE_KEY = 'zen-gomoku:place-sound-enabled'
+const PLAYBACK_RATE = 1.75
 
-let audio: HTMLAudioElement | null = null
-let loadStarted = false
+let template: HTMLAudioElement | null = null
+let unlocked = false
 
 function readEnabled(): boolean {
   try {
@@ -23,23 +28,47 @@ function readEnabled(): boolean {
 
 let enabled = typeof localStorage !== 'undefined' ? readEnabled() : true
 
-function ensureAudio(): HTMLAudioElement | null {
+function ensureTemplate(): HTMLAudioElement | null {
   if (typeof Audio === 'undefined') return null
-  if (!audio) {
-    audio = new Audio()
-    audio.preload = 'auto'
+  if (!template) {
+    template = new Audio(placeStoneUrl)
+    template.preload = 'auto'
   }
-  if (!loadStarted) {
-    loadStarted = true
-    audio.src = placeStoneUrl
-  }
-  return audio
+  return template
 }
 
 /** 预加载（可在应用挂载时调用，失败静默） */
 export function preloadPlaceSound(): void {
   try {
-    ensureAudio()?.load()
+    ensureTemplate()?.load()
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * 在用户手势回调中调用一次，解锁后续 AI 落子的自动播放。
+ * 静音播放并立即 pause，用户无感。
+ */
+export function unlockPlaceSound(): void {
+  if (unlocked) return
+  const base = ensureTemplate()
+  if (!base) return
+  try {
+    const prevVol = base.volume
+    base.volume = 0
+    base.playbackRate = 1
+    void base
+      .play()
+      .then(() => {
+        base.pause()
+        base.currentTime = 0
+        base.volume = prevVol
+        unlocked = true
+      })
+      .catch(() => {
+        base.volume = prevVol
+      })
   } catch {
     /* ignore */
   }
@@ -65,17 +94,17 @@ export function togglePlaceSoundEnabled(): boolean {
 
 /**
  * 播放落子声（人机/人人/AI 共用）。
- * 需在用户手势后浏览器才允许自动播放；首次落子即可解锁。
  */
 export function playPlaceSound(): void {
   if (!enabled) return
-  const el = ensureAudio()
-  if (!el) return
+  const base = ensureTemplate()
+  if (!base) return
   try {
-    el.currentTime = 0
-    el.playbackRate = 1.75
+    const el = base.cloneNode(true) as HTMLAudioElement
+    el.playbackRate = PLAYBACK_RATE
+    el.volume = 1
     void el.play().catch(() => {
-      /* 自动播放受限时忽略 */
+      /* 未解锁或环境限制时忽略；下次用户手势 unlock 后再可播 */
     })
   } catch {
     /* ignore */

--- a/src/components/game/GameBoard.vue
+++ b/src/components/game/GameBoard.vue
@@ -139,12 +139,11 @@ watch(
   { deep: true }
 )
 
-/** 实际落子（含 AI）：音效 + 缩放；复盘 scrub 不触发 */
+/** 实际落子（含 AI）：音效 + 缩放。history 变长才触发（复盘 scrub 不增 length） */
 watch(
   () => history.value.length,
   (len, prev) => {
     if (len <= (prev ?? 0)) return
-    if (!isAtLiveEdge.value) return
     playPlaceSound()
     startPlacePulse()
   }

--- a/src/components/game/GameModeBar.vue
+++ b/src/components/game/GameModeBar.vue
@@ -9,6 +9,7 @@ import {
 import {
   isPlaceSoundEnabled,
   togglePlaceSoundEnabled,
+  unlockPlaceSound,
 } from '../../audio'
 
 const gameStore = useGameStore()
@@ -16,20 +17,24 @@ const { vsAi, aiThinking, aiDifficulty, humanFirst } = storeToRefs(gameStore)
 const soundOn = ref(isPlaceSoundEnabled())
 
 function toggleVsAi() {
+  unlockPlaceSound()
   gameStore.setVsAi(!vsAi.value)
 }
 
 function onDifficultyChange(event: Event) {
+  unlockPlaceSound()
   const value = (event.target as HTMLSelectElement).value as AiDifficulty
   gameStore.setAiDifficulty(value)
 }
 
 function onFirstChange(event: Event) {
+  unlockPlaceSound()
   const value = (event.target as HTMLSelectElement).value
   gameStore.setHumanFirst(value === 'human')
 }
 
 function onToggleSound() {
+  unlockPlaceSound()
   soundOn.value = togglePlaceSoundEnabled()
 }
 </script>

--- a/src/hooks/useBoardPointer.ts
+++ b/src/hooks/useBoardPointer.ts
@@ -5,6 +5,7 @@
 
 import type { Ref } from 'vue'
 import { pointerEventToLogical } from '../renderer/pointerMapper'
+import { unlockPlaceSound } from '../audio'
 
 export interface UseBoardPointerOptions {
   canvasRef: Ref<HTMLCanvasElement | null>
@@ -24,6 +25,10 @@ export function useBoardPointer(options: UseBoardPointerOptions) {
     // 忽略多指副指针、鼠标非主键（右键/中键）
     if (!e.isPrimary) return
     if (e.pointerType === 'mouse' && e.button !== 0) return
+
+    // 用户手势中解锁音效，保证随后 AI 落子也能出声
+    unlockPlaceSound()
+
     if (!options.canPlace()) return
 
     const canvas = options.canvasRef.value


### PR DESCRIPTION
## Summary
- 每次落子用 `cloneNode` 播放，避免人机连下时单例 `Audio` 被打断而静默失败
- 在棋盘点击与模式栏操作中调用 `unlockPlaceSound()`，满足浏览器自动播放策略，保证 AI 落子也能出声
- 去掉 history 监听对 `isAtLiveEdge` 的依赖，只要棋谱真正变长就播音效

## Test plan
- [ ] 人人对战连续落子，每步都有音效
- [ ] 人机对战：自己落子后 AI 回手，两步都有音效
- [ ] AI 先手：先点模式栏或棋盘解锁后，AI 首子与后续落子均有音效
- [ ] 关闭音效开关后无声；再打开后恢复
- [ ] 复盘 scrub 不额外触发落子音效


Made with [Cursor](https://cursor.com)