### PR TITLE
fix: AI 开局多样化 + 老师棋谱导出进度

### DIFF
--- a/scripts/generate-teacher-records.ts
+++ b/scripts/generate-teacher-records.ts
@@ -12,7 +12,7 @@ import path from 'node:path'
 import { RULE_FREESTYLE, RULE_RENJU_CN, isRuleSetId, type RuleSetId } from '../src/core'
 import { generateTeacherRecords, recordsToJsonl } from '../src/training'
 import type { AiDifficulty } from '../src/ai'
-import type { OpeningMode } from '../src/training'
+import type { GenerateProgress, OpeningMode } from '../src/training'
 
 function printHelp(): void {
   console.log(`Usage: npm run generate:teacher-records -- [options]
@@ -73,6 +73,35 @@ function resolveRulesList(spec: string): RuleSetId[] {
   throw new Error(`未知 rules: ${spec}`)
 }
 
+function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '?'
+  if (ms < 1000) return `${Math.round(ms)}ms`
+  const sec = Math.round(ms / 1000)
+  if (sec < 60) return `${sec}s`
+  const min = Math.floor(sec / 60)
+  const rem = sec % 60
+  if (min < 60) return `${min}m${String(rem).padStart(2, '0')}s`
+  const hr = Math.floor(min / 60)
+  const remMin = min % 60
+  return `${hr}h${String(remMin).padStart(2, '0')}m`
+}
+
+function printProgress(rules: RuleSetId, info: GenerateProgress): void {
+  const { index, total, record, gameMs, elapsedMs } = info
+  const pct = ((index / total) * 100).toFixed(1)
+  const avg = elapsedMs / index
+  const eta = avg * (total - index)
+  const line =
+    `[${rules}] ${index}/${total} (${pct}%) | ` +
+    `last ${formatDuration(gameMs)} | elapsed ${formatDuration(elapsedMs)} | ` +
+    `ETA ${formatDuration(eta)} | ${record.status} ${record.moves.length}moves`
+  // 单行刷新，避免 1000 局刷屏；每局结束都会更新，不会「卡住」
+  process.stdout.write(`\r${line.padEnd(100)}`)
+  if (index === total) {
+    process.stdout.write('\n')
+  }
+}
+
 async function main(): Promise<void> {
   const opts = parseArgs(process.argv.slice(2))
   const rulesList = resolveRulesList(opts.rules)
@@ -89,6 +118,7 @@ async function main(): Promise<void> {
       difficulty: opts.difficulty,
       openingMode: opts.opening,
       randomExtraMoves: opts.extra,
+      onProgress: (info) => printProgress(rules, info),
     })
     const stamp = new Date().toISOString().replace(/[:.]/g, '-')
     const file = path.join(opts.out, `${rules}-${stamp}.jsonl`)
@@ -98,7 +128,10 @@ async function main(): Promise<void> {
       white: records.filter((r) => r.status === 'white_win').length,
       draw: records.filter((r) => r.status === 'draw').length,
     }
-    console.log(`Wrote ${records.length} records → ${file} (${Date.now() - started}ms)`, wins)
+    console.log(
+      `Wrote ${records.length} records → ${file} (${formatDuration(Date.now() - started)})`,
+      wins
+    )
   }
 }
 

--- a/src/ai/HeuristicAgent.ts
+++ b/src/ai/HeuristicAgent.ts
@@ -12,6 +12,8 @@ import {
   scoreEmptyCell,
   listNeighborCandidates,
   DEFAULT_NEIGHBOR_RADIUS,
+  OPPONENT_SCORE,
+  SELF_SCORE,
 } from './evaluate'
 import { RandomAgent } from './RandomAgent'
 import { DEFAULT_RULE_SET, type RuleSetId } from '../core/rules'
@@ -51,12 +53,7 @@ export class HeuristicAgent implements IAgent {
     const opp = (player === 1 ? 2 : 1) as 1 | 2
     const selfCounts = buildWinsCounts(board, this.wins, this.winsCount, player)
     const oppCounts = buildWinsCounts(board, this.wins, this.winsCount, opp)
-    const pool = listNeighborCandidates(
-      board,
-      DEFAULT_NEIGHBOR_RADIUS,
-      player,
-      this.rules
-    )
+    const pool = listNeighborCandidates(board, DEFAULT_NEIGHBOR_RADIUS, player, this.rules)
 
     let max = -1
     const best: AiMove[] = []
@@ -84,6 +81,32 @@ export class HeuristicAgent implements IAgent {
     if (best.length === 0 || max <= 0) {
       return this.fallback.getNextMove(board)
     }
+
+    const critical = Math.min(OPPONENT_SCORE[4]!, SELF_SCORE[4]!)
+    // 开局且无冲四级紧急手：在 Top-3 中抽样，增加变化
+    if (stoneCount < 8 && max < critical) {
+      const scored = pool
+        .map((m) => ({
+          move: m,
+          score: scoreEmptyCell(
+            m.row,
+            m.col,
+            player,
+            selfCounts,
+            oppCounts,
+            this.wins,
+            this.winsCount,
+            this.boardSize
+          ),
+        }))
+        .filter((s) => s.score > 0)
+        .sort((a, b) => b.score - a.score)
+      const topN = scored.slice(0, Math.min(3, scored.length))
+      if (topN.length > 0) {
+        return topN[Math.floor(Math.random() * topN.length)]!.move
+      }
+    }
+
     return best[Math.floor(Math.random() * best.length)] ?? null
   }
 }

--- a/src/ai/MinimaxAgent.ts
+++ b/src/ai/MinimaxAgent.ts
@@ -78,8 +78,7 @@ export class MinimaxAgent implements IAgent {
       return { row: mid, col: mid }
     }
 
-    this.deadline =
-      this.timeLimitMs > 0 ? Date.now() + this.timeLimitMs : Number.POSITIVE_INFINITY
+    this.deadline = this.timeLimitMs > 0 ? Date.now() + this.timeLimitMs : Number.POSITIVE_INFINITY
     this.aborted = false
 
     let best: AiMove | null = null
@@ -106,11 +105,7 @@ export class MinimaxAgent implements IAgent {
     return false
   }
 
-  private searchRoot(
-    board: number[][],
-    aiPlayer: AiPlayer,
-    depth: number
-  ): AiMove | null {
+  private searchRoot(board: number[][], aiPlayer: AiPlayer, depth: number): AiMove | null {
     const moves = listOrderedCandidates(
       board,
       aiPlayer,
@@ -124,6 +119,7 @@ export class MinimaxAgent implements IAgent {
 
     let bestMove = moves[0]!
     let bestScore = -Infinity
+    const tied: AiMove[] = []
     let alpha = -Infinity
     const beta = Infinity
 
@@ -140,11 +136,18 @@ export class MinimaxAgent implements IAgent {
       if (score > bestScore) {
         bestScore = score
         bestMove = move
+        tied.length = 0
+        tied.push(move)
+      } else if (score === bestScore) {
+        tied.push(move)
       }
       alpha = Math.max(alpha, bestScore)
       if (bestScore >= WIN_SCORE / 2) break
     }
 
+    if (tied.length > 1) {
+      return tied[Math.floor(Math.random() * tied.length)] ?? bestMove
+    }
     return bestMove
   }
 

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -20,3 +20,14 @@ export {
   type AiDifficulty,
   type AiDifficultyOption,
 } from './difficulty'
+export {
+  OpeningBookController,
+  expandOpeningSeeds,
+  DEFAULT_OPENING_SEEDS,
+  SEED_TENGEN,
+  SEED_HUAYUE,
+  SEED_PUYUE,
+  getOpeningSeedById,
+  type OpeningSeed,
+  type BookMove,
+} from './openingBook'

--- a/src/ai/openingBook.test.ts
+++ b/src/ai/openingBook.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { OpeningBookController, expandOpeningSeeds, SEED_HUAYUE, SEED_TENGEN } from './openingBook'
+
+describe('openingBook', () => {
+  it('expandOpeningSeeds produces many symmetric lines', () => {
+    const seeds = expandOpeningSeeds()
+    expect(seeds.length).toBeGreaterThan(20)
+    expect(seeds.some((s) => s.id === 'tengen')).toBe(true)
+  })
+
+  it('controller follows book then returns null off-book', () => {
+    let i = 0
+    const seq = [0.0, 0.1, 0.2]
+    const book = new OpeningBookController([SEED_HUAYUE], () => seq[i++] ?? 0)
+    book.reset()
+    expect(book.getLine()?.[0]).toEqual({ r: 7, c: 7, player: 1 })
+
+    const m1 = book.nextMove([], 1)
+    expect(m1).toEqual({ row: 7, col: 7 })
+
+    const m2 = book.nextMove([{ row: 7, col: 7, player: 1 }], 2)
+    expect(m2).toEqual({ row: 7, col: 8 })
+
+    const m3 = book.nextMove(
+      [
+        { row: 7, col: 7, player: 1 },
+        { row: 7, col: 8, player: 2 },
+      ],
+      1
+    )
+    expect(m3).toEqual({ row: 6, col: 8 })
+
+    const off = book.nextMove(
+      [
+        { row: 7, col: 7, player: 1 },
+        { row: 0, col: 0, player: 2 },
+      ],
+      1
+    )
+    expect(off).toBeNull()
+  })
+
+  it('tengen-only line only suggests first move for black', () => {
+    const book = new OpeningBookController([SEED_TENGEN], () => 0)
+    book.reset()
+    expect(book.nextMove([], 1)).toEqual({ row: 7, col: 7 })
+    expect(book.nextMove([{ row: 7, col: 7, player: 1 }], 2)).toBeNull()
+  })
+})

--- a/src/ai/openingBook.ts
+++ b/src/ai/openingBook.ts
@@ -1,0 +1,177 @@
+/**
+ * 人机 / 老师对弈共用开局书：经典形 + 八对称，避免每盘同一开局。
+ * 坐标 15×15、0-based；花月/浦月等为教学近似形。
+ */
+
+import type { AiMove, AiPlayer } from './types'
+
+export interface BookMove {
+  r: number
+  c: number
+  player: AiPlayer
+}
+
+export interface OpeningSeed {
+  id: string
+  name: string
+  /** 含天元在内的前缀着法；player 交替且黑先 */
+  moves: BookMove[]
+}
+
+const C = 7
+
+const TENGEN: BookMove = { r: C, c: C, player: 1 }
+
+/** 基础种子（未展开对称）；白 2 与黑 3 相对天元 */
+const BASE_SEEDS: readonly OpeningSeed[] = [
+  {
+    id: 'huayue',
+    name: '花月',
+    moves: [TENGEN, { r: 7, c: 8, player: 2 }, { r: 6, c: 8, player: 1 }],
+  },
+  {
+    id: 'puyue',
+    name: '浦月',
+    moves: [TENGEN, { r: 7, c: 8, player: 2 }, { r: 6, c: 9, player: 1 }],
+  },
+  {
+    id: 'zhixia',
+    name: '直下',
+    moves: [TENGEN, { r: 6, c: 7, player: 2 }, { r: 5, c: 7, player: 1 }],
+  },
+  {
+    id: 'xieer',
+    name: '斜二',
+    moves: [TENGEN, { r: 6, c: 8, player: 2 }, { r: 5, c: 8, player: 1 }],
+  },
+  {
+    id: 'pangxia',
+    name: '旁下',
+    moves: [TENGEN, { r: 7, c: 9, player: 2 }, { r: 6, c: 8, player: 1 }],
+  },
+]
+
+/** 相对天元的 8 个二面体变换 */
+const TRANSFORMS: readonly ((dr: number, dc: number) => [number, number])[] = [
+  (dr, dc) => [dr, dc],
+  (dr, dc) => [dc, -dr],
+  (dr, dc) => [-dr, -dc],
+  (dr, dc) => [-dc, dr],
+  (dr, dc) => [dr, -dc],
+  (dr, dc) => [-dc, -dr],
+  (dr, dc) => [-dr, dc],
+  (dr, dc) => [dc, dr],
+]
+
+function applyTransform(
+  moves: readonly BookMove[],
+  transform: (dr: number, dc: number) => [number, number]
+): BookMove[] {
+  return moves.map((m) => {
+    if (m.r === C && m.c === C) return { ...m }
+    const [dr, dc] = transform(m.r - C, m.c - C)
+    return { r: C + dr, c: C + dc, player: m.player }
+  })
+}
+
+function inBoard(r: number, c: number): boolean {
+  return r >= 0 && r < 15 && c >= 0 && c < 15
+}
+
+/** 展开对称后的全部合法种子（供训练导出与人机开局） */
+export function expandOpeningSeeds(bases: readonly OpeningSeed[] = BASE_SEEDS): OpeningSeed[] {
+  const out: OpeningSeed[] = []
+  for (const base of bases) {
+    for (let t = 0; t < TRANSFORMS.length; t++) {
+      const moves = applyTransform(base.moves, TRANSFORMS[t]!)
+      if (moves.every((m) => inBoard(m.r, m.c))) {
+        out.push({
+          id: `${base.id}-t${t}`,
+          name: base.name,
+          moves,
+        })
+      }
+    }
+  }
+  // 仅天元：让「纯启发」也占一小部分概率时由 controller 权重处理；此处仍放入一份
+  out.push({ id: 'tengen', name: '天元', moves: [TENGEN] })
+  return out
+}
+
+export const DEFAULT_OPENING_SEEDS: readonly OpeningSeed[] = expandOpeningSeeds()
+
+export const SEED_TENGEN: OpeningSeed = {
+  id: 'tengen',
+  name: '天元',
+  moves: [TENGEN],
+}
+
+export const SEED_HUAYUE = BASE_SEEDS[0]!
+export const SEED_PUYUE = BASE_SEEDS[1]!
+
+export function getOpeningSeedById(
+  id: string,
+  seeds: readonly OpeningSeed[] = DEFAULT_OPENING_SEEDS
+): OpeningSeed | undefined {
+  return seeds.find((s) => s.id === id)
+}
+
+export interface HistoryStone {
+  row: number
+  col: number
+  player: number
+}
+
+/**
+ * 对局级开局书控制器：每局 reset 抽一条线；着法偏离书则不再给书着（悔棋回到前缀后可再跟书）。
+ */
+export class OpeningBookController {
+  private line: BookMove[] | null = null
+  private readonly pool: readonly OpeningSeed[]
+  private readonly random: () => number
+
+  constructor(
+    seeds: readonly OpeningSeed[] = DEFAULT_OPENING_SEEDS,
+    random: () => number = Math.random
+  ) {
+    this.pool = seeds.length > 0 ? seeds : [SEED_TENGEN]
+    this.random = random
+  }
+
+  reset(): void {
+    const seed = this.pool[Math.floor(this.random() * this.pool.length)]!
+    this.line = seed.moves.map((m) => ({ ...m }))
+  }
+
+  /** 当前选用的开局线（只读，调试用） */
+  getLine(): readonly BookMove[] | null {
+    return this.line
+  }
+
+  /**
+   * 若 history 仍匹配开局书，且下一手轮到 player，返回书着；否则 null。
+   */
+  nextMove(history: readonly HistoryStone[], player: AiPlayer): AiMove | null {
+    if (!this.line) return null
+
+    for (let i = 0; i < history.length; i++) {
+      const expected = this.line[i]
+      const actual = history[i]
+      if (
+        !expected ||
+        !actual ||
+        expected.r !== actual.row ||
+        expected.c !== actual.col ||
+        expected.player !== actual.player
+      ) {
+        return null
+      }
+    }
+
+    const next = this.line[history.length]
+    if (!next) return null
+    if (next.player !== player) return null
+    if (!inBoard(next.r, next.c)) return null
+    return { row: next.r, col: next.c }
+  }
+}

--- a/src/stores/game.test.ts
+++ b/src/stores/game.test.ts
@@ -176,7 +176,11 @@ describe('useGameStore', () => {
     expect(store.aiThinking).toBe(true)
     await vi.advanceTimersByTimeAsync(300)
     await Promise.resolve()
-    expect(store.board[1]![1]).toBe(2)
+    expect(store.history).toHaveLength(2)
+    expect(store.history[1]!.player).toBe(2)
+    const wr = store.history[1]!.row
+    const wc = store.history[1]!.col
+    expect(store.board[wr]![wc]).toBe(2)
     expect(store.currentPlayer).toBe(1)
     expect(store.aiThinking).toBe(false)
     vi.useRealTimers()
@@ -315,10 +319,12 @@ describe('useGameStore', () => {
     await vi.advanceTimersByTimeAsync(300)
     await Promise.resolve()
     expect(store.history).toHaveLength(2)
+    const aiRow = store.history[1]!.row
+    const aiCol = store.history[1]!.col
     expect(store.undoMove().success).toBe(true)
     expect(store.history).toHaveLength(0)
     expect(store.board[TENGEN_ROW]![TENGEN_COL]).toBe(0)
-    expect(store.board[1]![1]).toBe(0)
+    expect(store.board[aiRow]![aiCol]).toBe(0)
     expect(store.currentPlayer).toBe(1)
     expect(store.canPlay).toBe(true)
     vi.useRealTimers()
@@ -347,10 +353,29 @@ describe('useGameStore', () => {
     vi.useRealTimers()
   })
 
-  it('undoMove: empty history fails', () => {
-    const store = useGameStore()
-    expect(store.canUndo).toBe(false)
-    const r = store.undoMove()
-    expect(r.success).toBe(false)
+  it('vsAi: opening book diversifies white reply after tengen', async () => {
+    vi.useFakeTimers()
+    const replies = new Set<string>()
+    for (let i = 0; i < 24; i++) {
+      setActivePinia(createPinia())
+      const store = useGameStore()
+      store.setAgent({
+        name: 'never',
+        async getNextMove() {
+          return { row: 0, col: 0 }
+        },
+      })
+      store.setVsAi(true)
+      expect(store.placeStone(TENGEN_ROW, TENGEN_COL).success).toBe(true)
+      await vi.advanceTimersByTimeAsync(300)
+      await Promise.resolve()
+      expect(store.history.length).toBe(2)
+      const w = store.history[1]!
+      expect(w.player).toBe(2)
+      // 若跟书，不应总是落到 agent 的 (0,0)
+      replies.add(`${w.row},${w.col}`)
+    }
+    expect(replies.size).toBeGreaterThan(1)
+    vi.useRealTimers()
   })
 })

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -24,6 +24,7 @@ import { DEFAULT_RECORD_STORAGE_KEY, type KeyValueStorage } from '../storage'
 import {
   createAgentForDifficulty,
   DEFAULT_AI_DIFFICULTY,
+  OpeningBookController,
   type AiDifficulty,
   type IAgent,
 } from '../ai'
@@ -72,6 +73,8 @@ export const useGameStore = defineStore('game', () => {
   const rules = ref<RuleSetId>(DEFAULT_RULE_SET)
   let agent: IAgent = createAgentForDifficulty(DEFAULT_AI_DIFFICULTY, BOARD_SIZE, DEFAULT_RULE_SET)
   let aiToken = 0
+  const openingBook = new OpeningBookController()
+  openingBook.reset()
 
   function recreateAgent(): void {
     agent = createAgentForDifficulty(aiDifficulty.value, BOARD_SIZE, rules.value)
@@ -230,7 +233,8 @@ export const useGameStore = defineStore('game', () => {
       if (!vsAi.value || status.value !== 'playing') return
       if (currentPlayer.value !== aiPlayer.value) return
       const snapshot = board.value.map((row) => row.slice())
-      const move = await agent.getNextMove(snapshot)
+      const bookMove = openingBook.nextMove(history.value, aiPlayer.value)
+      const move = bookMove ?? (await agent.getNextMove(snapshot))
       if (token !== aiToken) return
       if (!move) return
       placeStone(move.row, move.col)
@@ -246,6 +250,7 @@ export const useGameStore = defineStore('game', () => {
     aiToken++
     aiThinking.value = false
     if (enabled) {
+      openingBook.reset()
       scheduleAiMove()
     }
   }
@@ -288,6 +293,7 @@ export const useGameStore = defineStore('game', () => {
     history.value = []
     status.value = 'playing'
     displayHistoryIndex.value = 0
+    openingBook.reset()
     scheduleAiMove()
   }
 
@@ -391,6 +397,7 @@ export const useGameStore = defineStore('game', () => {
     currentPlayer.value = rebuilt.currentPlayer
     status.value = rebuilt.status
     displayHistoryIndex.value = history.value.length
+    openingBook.reset()
     scheduleAiMove()
     return { success: true }
   }

--- a/src/training/generateTeacherRecords.ts
+++ b/src/training/generateTeacherRecords.ts
@@ -21,11 +21,24 @@ export interface GenerateTeacherRecordsOptions {
   seedProbability?: number
   maxMoves?: number
   random?: () => number
+  /** 每完成一局回调（用于 CLI 进度） */
+  onProgress?: (info: GenerateProgress) => void
   /** 单测可注入更快 Agent */
   createAgent?: (
     rules: RuleSetId,
     role: 'black' | 'white'
   ) => ReturnType<typeof createAgentForDifficulty>
+}
+
+export interface GenerateProgress {
+  /** 1-based */
+  index: number
+  total: number
+  record: GameRecord
+  /** 本局耗时 */
+  gameMs: number
+  /** 自本批开始累计耗时 */
+  elapsedMs: number
 }
 
 function pickSeed(seeds: readonly OpeningSeed[], random: () => number): OpeningSeed {
@@ -62,7 +75,9 @@ export async function generateTeacherRecords(
     ((rules: RuleSetId) => createAgentForDifficulty(difficulty, options.boardSize ?? 15, rules))
 
   const records: GameRecord[] = []
+  const batchStarted = Date.now()
   for (let i = 0; i < count; i++) {
+    const gameStarted = Date.now()
     const seed = pickSeed(seeds, random)
     const opening: OpeningPlan = {
       mode: openingMode,
@@ -80,6 +95,13 @@ export async function generateTeacherRecords(
       random,
     })
     records.push(record)
+    options.onProgress?.({
+      index: i + 1,
+      total: count,
+      record,
+      gameMs: Date.now() - gameStarted,
+      elapsedMs: Date.now() - batchStarted,
+    })
   }
   return records
 }

--- a/src/training/index.ts
+++ b/src/training/index.ts
@@ -8,6 +8,7 @@ export {
   generateTeacherRecords,
   recordsToJsonl,
   type GenerateTeacherRecordsOptions,
+  type GenerateProgress,
 } from './generateTeacherRecords'
 export {
   DEFAULT_OPENING_SEEDS,

--- a/src/training/openingSeeds.ts
+++ b/src/training/openingSeeds.ts
@@ -1,51 +1,13 @@
 /**
- * 经典开局种子（MVP）：天元开局后的前几手形状，用于丰富老师对弈开局分布。
- * 坐标为 15×15、0-based；花月/浦月为常见教学形近似，非完整定式库。
+ * 训练导出用开局种子：与人机开局书共用 `src/ai/openingBook`。
  */
-
-import type { RecordMove } from '../core'
-
-export interface OpeningSeed {
-  id: string
-  name: string
-  /** 含天元在内的前缀着法；player 须交替且黑先 */
-  moves: RecordMove[]
-}
-
-const TENGEN: RecordMove = { r: 7, c: 7, player: 1 }
-
-/** 仅天元 */
-export const SEED_TENGEN: OpeningSeed = {
-  id: 'tengen',
-  name: '天元',
-  moves: [TENGEN],
-}
-
-/**
- * 花月形近似：黑天元 → 白旁贴 → 黑斜二（直指标记中常称花月一类）
- * B(7,7) W(7,8) B(6,8)
- */
-export const SEED_HUAYUE: OpeningSeed = {
-  id: 'huayue',
-  name: '花月',
-  moves: [TENGEN, { r: 7, c: 8, player: 2 }, { r: 6, c: 8, player: 1 }],
-}
-
-/**
- * 浦月形近似：黑天元 → 白旁贴 → 黑斜跳（斜指系常见浦月方向）
- * B(7,7) W(7,8) B(6,9)
- */
-export const SEED_PUYUE: OpeningSeed = {
-  id: 'puyue',
-  name: '浦月',
-  moves: [TENGEN, { r: 7, c: 8, player: 2 }, { r: 6, c: 9, player: 1 }],
-}
-
-export const DEFAULT_OPENING_SEEDS: readonly OpeningSeed[] = [SEED_TENGEN, SEED_HUAYUE, SEED_PUYUE]
-
-export function getOpeningSeedById(
-  id: string,
-  seeds: readonly OpeningSeed[] = DEFAULT_OPENING_SEEDS
-): OpeningSeed | undefined {
-  return seeds.find((s) => s.id === id)
-}
+export {
+  DEFAULT_OPENING_SEEDS,
+  SEED_TENGEN,
+  SEED_HUAYUE,
+  SEED_PUYUE,
+  getOpeningSeedById,
+  expandOpeningSeeds,
+  type OpeningSeed,
+  type BookMove,
+} from '../ai/openingBook'

--- a/src/training/selfPlay.test.ts
+++ b/src/training/selfPlay.test.ts
@@ -105,4 +105,23 @@ describe('playSelfPlayGame / generateTeacherRecords', () => {
       expect('error' in rebuildFromRecord(r)).toBe(false)
     }
   })
+
+  it('onProgress fires once per game', async () => {
+    const events: number[] = []
+    await generateTeacherRecords({
+      rules: RULE_FREESTYLE,
+      count: 3,
+      openingMode: 'seed',
+      seedIds: ['tengen'],
+      random: () => 0.1,
+      createAgent: (rules) => createRandomLegalAgent(rules),
+      onProgress: (info) => {
+        events.push(info.index)
+        expect(info.total).toBe(3)
+        expect(info.gameMs).toBeGreaterThanOrEqual(0)
+        expect(info.elapsedMs).toBeGreaterThanOrEqual(info.gameMs)
+      },
+    })
+    expect(events).toEqual([1, 2, 3])
+  })
 })


### PR DESCRIPTION
## Summary
- Add shared opening book (花月/浦月等 + 8-way symmetry) for human-vs-AI so early replies are no longer identical every game; early soft diversity in Heuristic/Minimax.
- Teacher export reuses the expanded seed pool; CLI shows live progress (n/total, last/elapsed/ETA).
- Unit tests for opening book and vs-AI reply diversity.

## Test plan
- [ ] `npm run test` / `lint` / `build` pass
- [ ] `npm run generate:teacher-records -- --rules freestyle-v1 --count 5 --difficulty zhu` shows updating progress lines
- [ ] Human vs AI: start several games as black; AI white replies vary across games
- [ ] Restart / 重新开始 picks a new book line


Made with [Cursor](https://cursor.com)