### PR TITLE
fix: 活三必应，避免猪八戒/沙和尚漏堵

### DIFF
--- a/docs/project/issue-backlog.md
+++ b/docs/project/issue-backlog.md
@@ -78,16 +78,17 @@
 
 > **AlphaZero 风格路线（2026-08-05）**：设计见 [alphazero-lite.md](../design/alphazero-lite.md)。已定：独立训练仓；**自由 + 禁手两套规则并存**；**两个模型各训各用**；先模仿唐僧再自对弈。R0 [#54](https://github.com/IdEvEbI/zen-gomoku/issues/54)、R1 [#58](https://github.com/IdEvEbI/zen-gomoku/issues/58)（已关）；R2 [#60](https://github.com/IdEvEbI/zen-gomoku/issues/60)。
 
-| #   | 标题                                | 描述                                                                                                                                                     | 对应                 |
-| --- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| —   | **feat: Minimax + Alpha-Beta AI**   | ~~实现 Minimax~~ — 已合入（见 [ai-agents.md](../design/ai-agents.md)）。                                                                                 | Phase 2（已完成）    |
-| —   | **feat: 中国规则禁手 + 规则切换**   | 三三 / 四四 / 长连（仅黑）；与自由模式并存；规格 + 单测 + AI 走法过滤；禁手红叉。 → **[#54](https://github.com/IdEvEbI/zen-gomoku/issues/54)**           | alphazero-lite R0    |
-| —   | **feat: 老师棋谱导出（双规则）**    | **唐僧 vs 唐僧**批量互打；自由/禁手分套导出（带 `rules`）；开局扰动 + 可选花月/浦月等种子。 → **[#58](https://github.com/IdEvEbI/zen-gomoku/issues/58)** | alphazero-lite R1    |
-| —   | **chore: 新建 zen-gomoku-ml**       | 独立训练仓；`rules` 参数化；先自由后禁手两套模仿模型与 ONNX。 → **[#60](https://github.com/IdEvEbI/zen-gomoku/issues/60)**                               | alphazero-lite R2    |
-| —   | **feat: AlphaZeroAgent 按规则加载** | 本仓按当前规则加载对应 ONNX；人机可选；不上训练。                                                                                                        | alphazero-lite R3    |
-| —   | **feat: 自对弈闭环（可选）**        | 两套规则各自自对弈 + 擂台；产物回灌本仓。                                                                                                                | alphazero-lite R4    |
-| —   | **feat: 悔棋**                      | 从 `history` pop；人人 1 手、人机人+AI；恢复 board / 行棋方 / 终局状态。 → **[#51](https://github.com/IdEvEbI/zen-gomoku/issues/51)**                    | 架构 3.1             |
-| —   | **feat: 小程序/小游戏适配**         | 逻辑层复用 `src/core/`；视图与存储通过适配层对接小程序 setData / Canvas / 本地存储或云开发。                                                             | F-REQ-011, F-REQ-012 |
+| #   | 标题                                | 描述                                                                                                                                                            | 对应                 |
+| --- | ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| —   | **feat: Minimax + Alpha-Beta AI**   | ~~实现 Minimax~~ — 已合入（见 [ai-agents.md](../design/ai-agents.md)）。                                                                                        | Phase 2（已完成）    |
+| —   | **feat: 中国规则禁手 + 规则切换**   | 三三 / 四四 / 长连（仅黑）；与自由模式并存；规格 + 单测 + AI 走法过滤；禁手红叉。 → **[#54](https://github.com/IdEvEbI/zen-gomoku/issues/54)**                  | alphazero-lite R0    |
+| —   | **feat: 老师棋谱导出（双规则）**    | **唐僧 vs 唐僧**批量互打；自由/禁手分套导出（带 `rules`）；开局扰动 + 可选花月/浦月等种子。 → **[#58](https://github.com/IdEvEbI/zen-gomoku/issues/58)**        | alphazero-lite R1    |
+| —   | **chore: 新建 zen-gomoku-ml**       | 独立训练仓；`rules` 参数化；先自由后禁手两套模仿模型与 ONNX。 → **[#60](https://github.com/IdEvEbI/zen-gomoku/issues/60)**                                      | alphazero-lite R2    |
+| —   | **feat: AlphaZeroAgent 按规则加载** | 本仓按当前规则加载对应 ONNX；人机可选；不上训练。                                                                                                               | alphazero-lite R3    |
+| —   | **feat: 自对弈闭环（可选）**        | 两套规则各自自对弈 + 擂台；产物回灌本仓。                                                                                                                       | alphazero-lite R4    |
+| —   | **feat: 悔棋**                      | 从 `history` pop；人人 1 手、人机人+AI；恢复 board / 行棋方 / 终局状态。 → **[#51](https://github.com/IdEvEbI/zen-gomoku/issues/51)**                           | 架构 3.1             |
+| —   | **fix: 活三必应（猪八戒/沙和尚）**  | 开局软随机 / Top-K 失误不得漏堵活三；`URGENT_THREAT_SCORE` 门槛 + 攻防累加评分；单测覆盖斜向活三。 → **[#64](https://github.com/IdEvEbI/zen-gomoku/issues/64)** | AI 体验 / 棋力       |
+| —   | **feat: 小程序/小游戏适配**         | 逻辑层复用 `src/core/`；视图与存储通过适配层对接小程序 setData / Canvas / 本地存储或云开发。                                                                    | F-REQ-011, F-REQ-012 |
 
 ---
 

--- a/src/ai/HeuristicAgent.test.ts
+++ b/src/ai/HeuristicAgent.test.ts
@@ -1,10 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import {
-  HeuristicAgent,
-  RandomAgent,
-  nextPlayerFromBoard,
-  buildWinsTable,
-} from './index'
+import { HeuristicAgent, RandomAgent, nextPlayerFromBoard, buildWinsTable } from './index'
 
 function emptyBoard(size = 15): number[][] {
   return Array.from({ length: size }, () => Array(size).fill(0))
@@ -79,5 +74,46 @@ describe('HeuristicAgent', () => {
     expect(move).not.toBeNull()
     expect(move!.row).toBe(5)
     expect(move!.col).toBe(4)
+  })
+
+  it('blocks open three on diagonal (must not soft-random away)', async () => {
+    const agent = new HeuristicAgent(15)
+    // 黑斜向活三 (6,6)(7,7)(8,8)，两端 (5,5)/(9,9)；白应堵其一
+    // 子数 7 < 8，曾触发软随机漏堵
+    const board = emptyBoard()
+    board[6]![6] = 1
+    board[7]![7] = 1
+    board[8]![8] = 1
+    board[0]![0] = 2
+    board[0]![1] = 2
+    board[0]![2] = 2
+    board[1]![0] = 1 // black 4, white 3 → white to move
+    for (let i = 0; i < 20; i++) {
+      const move = await agent.getNextMove(board)
+      expect(move).not.toBeNull()
+      const end = (move!.row === 5 && move!.col === 5) || (move!.row === 9 && move!.col === 9)
+      expect(end).toBe(true)
+    }
+  })
+})
+
+describe('ShaHeshangAgent', () => {
+  it('always blocks open three (never misses for variety)', async () => {
+    const { ShaHeshangAgent } = await import('./ShaHeshangAgent')
+    const agent = new ShaHeshangAgent({ bestMoveChance: 0.1 })
+    const board = emptyBoard()
+    board[6]![6] = 1
+    board[7]![7] = 1
+    board[8]![8] = 1
+    board[0]![0] = 2
+    board[0]![1] = 2
+    board[0]![2] = 2
+    board[1]![0] = 1
+    for (let i = 0; i < 30; i++) {
+      const move = await agent.getNextMove(board)
+      expect(move).not.toBeNull()
+      const end = (move!.row === 5 && move!.col === 5) || (move!.row === 9 && move!.col === 9)
+      expect(end).toBe(true)
+    }
   })
 })

--- a/src/ai/HeuristicAgent.ts
+++ b/src/ai/HeuristicAgent.ts
@@ -2,7 +2,7 @@
  * 赢法数组启发式 Agent（Phase 1 / 猪八戒）
  * - 开局偏中心
  * - 只对邻近已有子的空位打分（空盘除外）
- * - 进攻略重于防守；四连权重最高
+ * - 活三及以上必须应手；无紧急威胁时开局可在同分附近略作变化
  */
 
 import type { IAgent, AiMove } from './types'
@@ -12,8 +12,7 @@ import {
   scoreEmptyCell,
   listNeighborCandidates,
   DEFAULT_NEIGHBOR_RADIUS,
-  OPPONENT_SCORE,
-  SELF_SCORE,
+  URGENT_THREAT_SCORE,
 } from './evaluate'
 import { RandomAgent } from './RandomAgent'
 import { DEFAULT_RULE_SET, type RuleSetId } from '../core/rules'
@@ -55,58 +54,45 @@ export class HeuristicAgent implements IAgent {
     const oppCounts = buildWinsCounts(board, this.wins, this.winsCount, opp)
     const pool = listNeighborCandidates(board, DEFAULT_NEIGHBOR_RADIUS, player, this.rules)
 
-    let max = -1
-    const best: AiMove[] = []
+    const scored = pool
+      .map((m) => ({
+        move: m,
+        score: scoreEmptyCell(
+          m.row,
+          m.col,
+          player,
+          selfCounts,
+          oppCounts,
+          this.wins,
+          this.winsCount,
+          this.boardSize
+        ),
+      }))
+      .filter((s) => s.score > 0)
+      .sort((a, b) => b.score - a.score)
 
-    for (const { row, col } of pool) {
-      const total = scoreEmptyCell(
-        row,
-        col,
-        player,
-        selfCounts,
-        oppCounts,
-        this.wins,
-        this.winsCount,
-        this.boardSize
-      )
-      if (total > max) {
-        max = total
-        best.length = 0
-        best.push({ row, col })
-      } else if (total === max) {
-        best.push({ row, col })
-      }
-    }
-
-    if (best.length === 0 || max <= 0) {
+    if (scored.length === 0) {
       return this.fallback.getNextMove(board)
     }
 
-    const critical = Math.min(OPPONENT_SCORE[4]!, SELF_SCORE[4]!)
-    // 开局且无冲四级紧急手：在 Top-3 中抽样，增加变化
-    if (stoneCount < 8 && max < critical) {
-      const scored = pool
-        .map((m) => ({
-          move: m,
-          score: scoreEmptyCell(
-            m.row,
-            m.col,
-            player,
-            selfCounts,
-            oppCounts,
-            this.wins,
-            this.winsCount,
-            this.boardSize
-          ),
-        }))
-        .filter((s) => s.score > 0)
-        .sort((a, b) => b.score - a.score)
-      const topN = scored.slice(0, Math.min(3, scored.length))
-      if (topN.length > 0) {
-        return topN[Math.floor(Math.random() * topN.length)]!.move
+    const bestScore = scored[0]!.score
+
+    // 活三/冲四等紧急威胁：必须走最高分（可同分随机）
+    if (bestScore >= URGENT_THREAT_SCORE) {
+      const urgent = scored.filter((s) => s.score >= bestScore - 1e-6)
+      return urgent[Math.floor(Math.random() * urgent.length)]!.move
+    }
+
+    // 开局无紧急手：仅在「接近最优」的候选里抽样，避免漏应又保持变化
+    if (stoneCount < 8) {
+      const nearBest = scored.filter((s) => s.score >= bestScore - 40)
+      const pick = nearBest.slice(0, Math.min(3, nearBest.length))
+      if (pick.length > 0) {
+        return pick[Math.floor(Math.random() * pick.length)]!.move
       }
     }
 
-    return best[Math.floor(Math.random() * best.length)] ?? null
+    const tied = scored.filter((s) => s.score >= bestScore - 1e-6)
+    return tied[Math.floor(Math.random() * tied.length)]!.move
   }
 }

--- a/src/ai/ShaHeshangAgent.ts
+++ b/src/ai/ShaHeshangAgent.ts
@@ -1,7 +1,7 @@
 /**
  * 沙和尚：弱于纯启发，但不瞎下
  * - 从不在全盘随机空位落子（避免「弱智」体感）
- * - 必应冲四 / 堵四等高威胁
+ * - 必应活三 / 冲四等高威胁
  * - 其余在启发 Top-K 中按权重抽样（偏最优，偶发次优）
  */
 
@@ -12,14 +12,10 @@ import {
   scoreEmptyCell,
   listNeighborCandidates,
   DEFAULT_NEIGHBOR_RADIUS,
-  OPPONENT_SCORE,
-  SELF_SCORE,
+  URGENT_THREAT_SCORE,
 } from './evaluate'
 import { RandomAgent } from './RandomAgent'
 import { DEFAULT_RULE_SET, type RuleSetId } from '../core/rules'
-
-/** 四连档启发分：必须应手，不允许「失误」 */
-const CRITICAL_SCORE = Math.min(OPPONENT_SCORE[4]!, SELF_SCORE[4]!)
 
 export interface ShaHeshangOptions {
   /** 启发 Top-K（在非关键局面中抽样） */
@@ -72,12 +68,7 @@ export class ShaHeshangAgent implements IAgent {
     const opp = (player === 1 ? 2 : 1) as 1 | 2
     const selfCounts = buildWinsCounts(board, this.wins, this.winsCount, player)
     const oppCounts = buildWinsCounts(board, this.wins, this.winsCount, opp)
-    const pool = listNeighborCandidates(
-      board,
-      DEFAULT_NEIGHBOR_RADIUS,
-      player,
-      this.rules
-    )
+    const pool = listNeighborCandidates(board, DEFAULT_NEIGHBOR_RADIUS, player, this.rules)
 
     const scored = pool.map((m) => ({
       move: m,
@@ -98,8 +89,10 @@ export class ShaHeshangAgent implements IAgent {
     if (top.length === 0) return this.fallback.getNextMove(board)
 
     const best = top[0]!
-    if (best.score >= CRITICAL_SCORE) {
-      return best.move
+    // 活三及以上：不允许抽次优漏堵
+    if (best.score >= URGENT_THREAT_SCORE) {
+      const urgent = top.filter((s) => s.score >= best.score - 1e-6)
+      return urgent[Math.floor(Math.random() * urgent.length)]!.move
     }
 
     if (top.length === 1 || Math.random() < this.bestMoveChance) {

--- a/src/ai/evaluate.ts
+++ b/src/ai/evaluate.ts
@@ -6,14 +6,15 @@ import type { AiMove, AiPlayer } from './types'
 import { listEmptyCells } from './types'
 import { buildWinsCounts } from './winsTable'
 import { isLegalMove } from '../core/forbiddenMoves'
-import {
-  DEFAULT_RULE_SET,
-  RULE_FREESTYLE,
-  type RuleSetId,
-} from '../core/rules'
+import { DEFAULT_RULE_SET, RULE_FREESTYLE, type RuleSetId } from '../core/rules'
 
 export const OPPONENT_SCORE = [0, 200, 400, 2000, 10000] as const
 export const SELF_SCORE = [0, 220, 420, 2400, 20000] as const
+
+/** 冲四档：必应 */
+export const CRITICAL_THREAT_SCORE = Math.min(OPPONENT_SCORE[4]!, SELF_SCORE[4]!)
+/** 活三/冲三档：亦必须应手，禁止软随机漏堵 */
+export const URGENT_THREAT_SCORE = Math.min(OPPONENT_SCORE[3]!, SELF_SCORE[3]!)
 
 /** 终局分，须远大于启发累加 */
 export const WIN_SCORE = 10_000_000
@@ -77,7 +78,9 @@ export function scoreEmptyCell(
   const mid = (boardSize - 1) / 2
   const dist = Math.abs(row - mid) + Math.abs(col - mid)
   const center = Math.max(0, 50 - dist * 3)
-  return Math.max(selfScore, oppScore) + center
+  // 攻防都计入，且高威胁防守略加权，避免「只进攻不堵活三」
+  const defenseBias = oppScore >= URGENT_THREAT_SCORE ? oppScore * 0.15 : 0
+  return selfScore + oppScore + defenseBias + center
 }
 
 export function hasNeighbor(
@@ -140,16 +143,7 @@ export function listOrderedCandidates(
 
   const scored = candidates.map((m) => ({
     move: m,
-    score: scoreEmptyCell(
-      m.row,
-      m.col,
-      player,
-      selfCounts,
-      oppCounts,
-      wins,
-      winsCount,
-      boardSize
-    ),
+    score: scoreEmptyCell(m.row, m.col, player, selfCounts, oppCounts, wins, winsCount, boardSize),
   }))
   scored.sort((a, b) => b.score - a.score)
   return scored.slice(0, Math.max(1, limit)).map((s) => s.move)

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -7,6 +7,10 @@ export {
   listOrderedCandidates,
   listNeighborCandidates,
   WIN_SCORE,
+  CRITICAL_THREAT_SCORE,
+  URGENT_THREAT_SCORE,
+  OPPONENT_SCORE,
+  SELF_SCORE,
 } from './evaluate'
 export { RandomAgent } from './RandomAgent'
 export { HeuristicAgent } from './HeuristicAgent'


### PR DESCRIPTION
## Summary
- 将猪八戒开局软随机与沙和尚 Top-K「失误」的必应门槛从冲四下调到活三（`URGENT_THREAT_SCORE`），避免漏堵斜向/直线活三
- `scoreEmptyCell` 改为攻防累加并略加重高威胁防守，减少「只进攻不堵」
- 补充斜向活三单测；同步 `issue-backlog` → [#64](https://github.com/IdEvEbI/zen-gomoku/issues/64)

Closes #64

## Test plan
- [ ] `npm run test` / `lint` / `build` 通过
- [ ] 人机选猪八戒 freestyle：故意走斜向活三，白方应堵两端之一
- [ ] 人机选沙和尚：同样局面多次重开，不应漏堵活三


Made with [Cursor](https://cursor.com)